### PR TITLE
MPMPHAI-39 : MeetingConfig.onMeetingTransitionItemActionToExecute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Changelog
 - Added parameter "include_person_title" to held_position.get_prefix_for_gender_and_number making it possible to generate "Madame la Directrice" sentence
 - Use vocabulary 'collective.contact.plonegroup.sorted_selected_organization_services' instead 'collective.contact.plonegroup.selected_organization_services'
 - Added utils.uncapitalize to lowerize first letter of a given string
+- Moved MeetingConfig.onMeetingTransitionItemTransitionToTrigger to MeetingConfig.onMeetingTransitionItemActionToExecute, in addition to be able to trigger a transition on every items
+  of a meeting when a transition is triggered on a meeting, it is now possible to execute a TAL expression
 
 4.1 (2019-08-23)
 ----------------

--- a/src/Products/PloneMeeting/config.py
+++ b/src/Products/PloneMeeting/config.py
@@ -325,6 +325,8 @@ ITEM_TRANSITION_WHEN_RETURNED_FROM_PROPOSING_GROUP_AFTER_CORRECTION = 'accept'
 
 EMPTY_STRING = '__empty_string__'
 
+EXECUTE_EXPR_VALUE = 'execute_tal_expression'
+
 
 def registerClasses():
     '''ArchGenXML generated code does not register Archetype classes at the

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -48,7 +48,7 @@ from Products.PloneMeeting.utils import applyOnTransitionFieldTransform
 from Products.PloneMeeting.utils import AdviceAfterTransitionEvent
 from Products.PloneMeeting.utils import ItemAfterTransitionEvent
 from Products.PloneMeeting.utils import MeetingAfterTransitionEvent
-from Products.PloneMeeting.utils import meetingTriggerTransitionOnLinkedItems
+from Products.PloneMeeting.utils import meetingExecuteActionOnLinkedItems
 from Products.PloneMeeting.utils import notifyModifiedAndReindex
 from Products.PloneMeeting.utils import sendMailIfRelevant
 from zExceptions import Redirect
@@ -98,8 +98,8 @@ def do(action, event):
         # Send mail if relevant
         sendMailIfRelevant(event.object, "meeting_state_changed_%s" % event.transition.id, 'View')
         # trigger some transitions on contained items depending on
-        # MeetingConfig.onMeetingTransitionItemTransitionToTrigger
-        meetingTriggerTransitionOnLinkedItems(event.object, event.transition.id)
+        # MeetingConfig.onMeetingTransitionItemActionToExecute
+        meetingExecuteActionOnLinkedItems(event.object, event.transition.id)
         # update modification date upon state change
         event.object.notifyModified()
     elif objectType == 'MeetingAdvice':

--- a/src/Products/PloneMeeting/profiles/__init__.py
+++ b/src/Products/PloneMeeting/profiles/__init__.py
@@ -434,7 +434,7 @@ class MeetingConfigDescriptor(Descriptor):
                          'dashboardMeetingLinkedItemsFilters', 'groupsHiddenInDashboardFilter',
                          'usersHiddenInDashboardFilter', 'workflowAdaptations', 'transitionsToConfirm',
                          'transitionsForPresentingAnItem', 'onTransitionFieldTransforms',
-                         'onMeetingTransitionItemTransitionToTrigger', 'meetingPresentItemWhenNoCurrentMeetingStates',
+                         'onMeetingTransitionItemActionToExecute', 'meetingPresentItemWhenNoCurrentMeetingStates',
                          'itemAutoSentToOtherMCStates', 'itemManualSentToOtherMCStates', 'advicesKeptOnSentToOtherMC',
                          'mailItemEvents', 'mailMeetingEvents',
                          'usedAdviceTypes', 'selectableAdvisers', 'itemAdviceStates',
@@ -613,7 +613,7 @@ class MeetingConfigDescriptor(Descriptor):
         self.transitionsToConfirm = []
         self.transitionsForPresentingAnItem = ['propose', 'validate', 'present']
         self.onTransitionFieldTransforms = []
-        self.onMeetingTransitionItemTransitionToTrigger = []
+        self.onMeetingTransitionItemActionToExecute = []
         self.meetingPresentItemWhenNoCurrentMeetingStates = []
         self.meetingManagerMayCorrectClosedMeeting = False
         self.itemAutoSentToOtherMCStates = ['accepted', ]

--- a/src/Products/PloneMeeting/profiles/testing/import_data.py
+++ b/src/Products/PloneMeeting/profiles/testing/import_data.py
@@ -290,44 +290,61 @@ meetingPma.itemDecidedStates = ('accepted', 'delayed', 'confirmed', 'itemarchive
 meetingPma.workflowAdaptations = []
 meetingPma.itemPositiveDecidedStates = ['accepted', 'confirmed']
 meetingPma.transitionsForPresentingAnItem = ('propose', 'validate', 'present', )
-meetingPma.onMeetingTransitionItemTransitionToTrigger = ({'meeting_transition': 'publish',
-                                                          'item_transition': 'itempublish'},
+meetingPma.onMeetingTransitionItemActionToExecute = (
+    {'meeting_transition': 'publish',
+     'item_action': 'itempublish',
+     'tal_expression': ''},
 
-                                                         {'meeting_transition': 'freeze',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'freeze',
-                                                          'item_transition': 'itemfreeze'},
+    {'meeting_transition': 'freeze',
+     'item_action': 'itempublish',
+     'tal_expression': ''},
+    {'meeting_transition': 'freeze',
+     'item_action': 'itemfreeze',
+     'tal_expression': ''},
 
-                                                         {'meeting_transition': 'decide',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'decide',
-                                                          'item_transition': 'itemfreeze'},
+    {'meeting_transition': 'decide',
+     'item_action': 'itempublish',
+     'tal_expression': ''},
+    {'meeting_transition': 'decide',
+     'item_action': 'itemfreeze',
+     'tal_expression': ''},
 
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'itemfreeze'},
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'accept'},
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'confirm'},
+    {'meeting_transition': 'close',
+     'item_action': 'itempublish',
+     'tal_expression': ''},
+    {'meeting_transition': 'close',
+     'item_action': 'itemfreeze',
+     'tal_expression': ''},
+    {'meeting_transition': 'close',
+     'item_action': 'accept',
+     'tal_expression': ''},
+    {'meeting_transition': 'close',
+     'item_action': 'confirm',
+     'tal_expression': ''},
 
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'itemfreeze'},
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'accept'},
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'confirm'},
+    {'meeting_transition': 'publish_decisions',
+     'item_action': 'itempublish',
+     'tal_expression': ''},
+    {'meeting_transition': 'publish_decisions',
+     'item_action': 'itemfreeze',
+     'tal_expression': ''},
+    {'meeting_transition': 'publish_decisions',
+     'item_action': 'accept',
+     'tal_expression': ''},
+    {'meeting_transition': 'publish_decisions',
+     'item_action': 'confirm',
+     'tal_expression': ''},
 
-                                                         {'meeting_transition': 'archive',
-                                                          'item_transition': 'itemarchive'},
+    {'meeting_transition': 'archive',
+     'item_action': 'itemarchive',
+     'tal_expression': ''},
 
-                                                         {'meeting_transition': 'backToCreated',
-                                                          'item_transition': 'backToItemPublished'},
-                                                         {'meeting_transition': 'backToCreated',
-                                                          'item_transition': 'backToPresented'},)
+    {'meeting_transition': 'backToCreated',
+     'item_action': 'backToItemPublished',
+     'tal_expression': ''},
+    {'meeting_transition': 'backToCreated',
+     'item_action': 'backToPresented',
+     'tal_expression': ''},)
 
 meetingPma.insertingMethodsOnAddItem = ({'insertingMethod': 'on_proposing_groups', 'reverse': '0'}, )
 meetingPma.useGroupsAsCategories = True
@@ -385,45 +402,8 @@ meetingPga.annexTypes = [financialAnalysis, legalAnalysis,
                          adviceAnnex, adviceLegalAnalysis, meetingAnnex]
 meetingPga.usedItemAttributes = ('description', 'toDiscuss', 'associatedGroups', 'itemIsSigned',)
 meetingPga.transitionsForPresentingAnItem = ('propose', 'validate', 'present', )
-meetingPga.onMeetingTransitionItemTransitionToTrigger = ({'meeting_transition': 'publish',
-                                                          'item_transition': 'itempublish'},
-
-                                                         {'meeting_transition': 'freeze',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'freeze',
-                                                          'item_transition': 'itemfreeze'},
-
-                                                         {'meeting_transition': 'decide',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'decide',
-                                                          'item_transition': 'itemfreeze'},
-
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'itemfreeze'},
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'accept'},
-                                                         {'meeting_transition': 'close',
-                                                          'item_transition': 'confirm'},
-
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'itempublish'},
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'itemfreeze'},
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'accept'},
-                                                         {'meeting_transition': 'publish_decisions',
-                                                          'item_transition': 'confirm'},
-
-                                                         {'meeting_transition': 'archive',
-                                                          'item_transition': 'itemarchive'},
-
-                                                         {'meeting_transition': 'backToCreated',
-                                                          'item_transition': 'backToItemPublished'},
-                                                         {'meeting_transition': 'backToCreated',
-                                                          'item_transition': 'backToPresented'},)
-
+meetingPga.onMeetingTransitionItemActionToExecute = deepcopy(
+    meetingPma.onMeetingTransitionItemActionToExecute)
 meetingPga.insertingMethodsOnAddItem = ({'insertingMethod': 'on_categories', 'reverse': '0'}, )
 meetingPga.useGroupsAsCategories = False
 meetingPga.itemTemplates = (template1, template2, )

--- a/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeeting.css.dtml
+++ b/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeeting.css.dtml
@@ -961,6 +961,13 @@ body[class*="itemtemplates"].template-manage-portlets a.link-parent {
     width: 10%;
 }
 
+/* make column displayed for MeetingConfig.onMeetingTransitionItemActionToExecute equals */
+#datagridwidget-table-onMeetingTransitionItemActionToExecute .datagridwidget-column-1,
+#datagridwidget-table-onMeetingTransitionItemActionToExecute .datagridwidget-column-2,
+#datagridwidget-table-onMeetingTransitionItemActionToExecute .datagridwidget-column-3 {
+    width: 33%;
+}
+
 /* display DX datagrid column in grey */
 .datagridwidget-table-view {
     border-color: #ddd;

--- a/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingconfig_view.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingconfig_view.pt
@@ -722,7 +722,7 @@
           </td>
         </tr>
         <tr valign="top">
-          <td tal:define="field python:here.getField('onMeetingTransitionItemTransitionToTrigger')">
+          <td tal:define="field python:here.getField('onMeetingTransitionItemActionToExecute')">
             <span metal:use-macro="here/widgets/field/macros/view" />
           </td>
           <td tal:define="field python:here.getField('meetingPresentItemWhenNoCurrentMeetingStates')">

--- a/src/Products/PloneMeeting/tests/helpers.py
+++ b/src/Products/PloneMeeting/tests/helpers.py
@@ -137,28 +137,28 @@ class PloneMeetingTestingHelpers:
         meeting = self.create('Meeting', date=meetingDate)
         # a meeting could be created with items if it has
         # recurring items...  But we can also add some more...
-        item1 = self.create('MeetingItem')  # id=o2
+        item1 = self.create('MeetingItem', title='Item 1')  # id=o2
         _set_proposing_group(item1, self.vendors)
         item1.setAssociatedGroups((self.developers_uid,))
         item1.setPrivacy('public')
         item1.setPollType('secret_separated')
         item1.setCategory('research')
-        item2 = self.create('MeetingItem')  # id=o3
+        item2 = self.create('MeetingItem', title='Item 2')  # id=o3
         _set_proposing_group(item2, self.developers)
         item2.setPrivacy('public')
         item2.setPollType('no_vote')
         item2.setCategory('development')
-        item3 = self.create('MeetingItem')  # id=o4
+        item3 = self.create('MeetingItem', title='Item 3')  # id=o4
         _set_proposing_group(item3, self.vendors)
         item3.setPrivacy('secret')
         item3.setPollType('freehand')
         item3.setCategory('development')
-        item4 = self.create('MeetingItem')  # id=o5
+        item4 = self.create('MeetingItem', title='Item 4')  # id=o5
         _set_proposing_group(item4, self.developers)
         item4.setPrivacy('secret')
         item4.setPollType('freehand')
         item4.setCategory('events')
-        item5 = self.create('MeetingItem')  # id=o6
+        item5 = self.create('MeetingItem', title='Item 5')  # id=o6
         _set_proposing_group(item5, self.vendors)
         item5.setPrivacy('public')
         item5.setPollType('secret')


### PR DESCRIPTION
Moved MeetingConfig.onMeetingTransitionItemTransitionToTrigger to MeetingConfig.onMeetingTransitionItemActionToExecute, in addition to be able to trigger a transition on every items of a meeting when a transition is triggered on a meeting, it is now possible to execute a TAL expression, see #MPMPHAI-39