### PR TITLE
- Added faceted filter `Copy groups`:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ Changelog
 - In `ToolPloneMeeting.pasteItem`, use `adopt_roles('Manager')` instead giving local role `Manager` to the `logged in user`.
 - Optimize `UpdateDelayAwareAdvicesView._computeQuery` to only consider organizations for which a delay aware advice is configured,
   this avoid very long queries that does not please `solr`
+- Added faceted filter `Copy groups`:
+
+  - Added `Products.PloneMeeting.vocabularies.copygroupsvocabulary` (faceted) and
+    `Products.PloneMeeting.vocabularies.itemcopygroupsvocabulary` (MeetingItem) vocabularies
+  - moved `MeetingItem.copyGroup` vocabulary from `listCopyGroups` to `Products.PloneMeeting.vocabularies.itemcopygroupsvocabulary`
+  - factorized the way advices and copy groups are displayed on item view (`displayAdvisers/displayCopyGroups`)
+  - adapted tests accordingly
 
 4.1.20.2 (2020-04-08)
 ---------------------

--- a/src/Products/PloneMeeting/Meeting.py
+++ b/src/Products/PloneMeeting/Meeting.py
@@ -101,9 +101,6 @@ logger = logging.getLogger('PloneMeeting')
 # PloneMeetingError-related constants -----------------------------------------
 BEFOREDELETE_ERROR = 'A BeforeDeleteException was raised by "%s" while ' \
     'trying to delete a meeting with id "%s"'
-NO_SECOND_LANGUAGE_ERROR = 'Unable to find the second supported language in ' \
-    'portal_languages, either only one language is supported, or more than 2 languages' \
-    'are supported.  Please contact system administrator.'
 
 
 # Adapters ---------------------------------------------------------------------

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -211,6 +211,7 @@ def _invalidateOrgRelatedCachedVocabularies():
     '''Clean cache for vocabularies using organizations.'''
     invalidate_cachekey_volatile_for("Products.PloneMeeting.vocabularies.proposinggroupsvocabulary")
     invalidate_cachekey_volatile_for("Products.PloneMeeting.vocabularies.associatedgroupsvocabulary")
+    invalidate_cachekey_volatile_for("Products.PloneMeeting.vocabularies.copygroupsvocabulary")
     invalidate_cachekey_volatile_for("Products.PloneMeeting.vocabularies.everyorganizationsvocabulary")
     invalidate_cachekey_volatile_for("Products.PloneMeeting.vocabularies.everyorganizationsacronymsvocabulary")
     invalidate_cachekey_volatile_for("Products.PloneMeeting.vocabularies.proposinggroupsforfacetedfiltervocabulary")

--- a/src/Products/PloneMeeting/faceted_conf/default_dashboard_items_widgets.xml
+++ b/src/Products/PloneMeeting/faceted_conf/default_dashboard_items_widgets.xml
@@ -468,7 +468,7 @@
    <property name="sortreversed">False</property>
   </criterion>
 
-   <criterion name="c27" i18n:attributes="title">
+  <criterion name="c27" i18n:attributes="title">
    <property name="widget">checkbox</property>
    <property name="title">Associated groups</property>
    <property name="position">top</property>
@@ -499,6 +499,25 @@
    <property name="count">False</property>
    <property name="sortcountable">False</property>
    <property name="hidezerocount">False</property>
+   <property name="maxitems">0</property>
+   <property name="sortreversed">False</property>
+  </criterion>
+
+  <criterion name="c29" i18n:attributes="title">
+   <property name="widget">checkbox</property>
+   <property name="title">Copy groups</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="index">getCopyGroups</property>
+   <property name="operator">or</property>
+   <property name="operator_visible">True</property>
+   <property
+      name="vocabulary">Products.PloneMeeting.vocabularies.copygroupsvocabulary</property>
+   <property name="catalog"></property>
    <property name="maxitems">0</property>
    <property name="sortreversed">False</property>
   </criterion>

--- a/src/Products/PloneMeeting/faceted_conf/upgrade_step_4104_add_item_widgets.xml
+++ b/src/Products/PloneMeeting/faceted_conf/upgrade_step_4104_add_item_widgets.xml
@@ -20,5 +20,24 @@
    <property name="sortreversed">False</property>
   </criterion>
 
+  <criterion name="c29" i18n:attributes="title">
+   <property name="widget">checkbox</property>
+   <property name="title">Copy groups</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="index">getCopyGroups</property>
+   <property name="operator">or</property>
+   <property name="operator_visible">True</property>
+   <property
+      name="vocabulary">Products.PloneMeeting.vocabularies.copygroupsvocabulary</property>
+   <property name="catalog"></property>
+   <property name="maxitems">0</property>
+   <property name="sortreversed">False</property>
+  </criterion>
+
  </criteria>
 </object>

--- a/src/Products/PloneMeeting/migrations/migrate_to_4104.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4104.py
@@ -71,6 +71,7 @@ class Migrate_To_4104(Migrator):
                     wfAdaptations = cfg.getWorkflowAdaptations()
                     wfAdaptations = wfAdaptations + ('meetingmanager_correct_closed_meeting', )
                     cfg.setWorkflowAdaptations(wfAdaptations)
+                delattr(cfg, 'meetingManagerMayCorrectClosedMeeting')
         logger.info('Done.')
 
     def _addItemNonAttendeesAttributeToMeetings(self):

--- a/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeeting.css.dtml
+++ b/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeeting.css.dtml
@@ -258,25 +258,28 @@ div.pm_search_no_result_info {
 #archetypes-fieldname-title2 input { font-size: 160%; width:99%;}
 /* display input for entering TAL expression as large as possible */
 input#form-widgets-as_copy_group_on {
-   width: 99%;
+    width: 99%;
 }
+/* when hovering [auto] on item view */
+strong.auto_info {
+    cursor: help;
+}
+
 .navigateItem {
     text-align: center;
     clear: both;
     margin-top: 0.5em;
 }
-
 .navigateItem img {
     vertical-align: baseline;
 }
 
-
 /* makes pm_workflowstate displays correctly on the right of byline */
 div#viewlet-below-content-title {
-   height: 1em;
+    height: 1em;
 }
 div#plone-document-byline {
-  float: left;
+    float: left;
 }
 div.pm_workflowstate {
     float: right;

--- a/src/Products/PloneMeeting/tests/testContacts.py
+++ b/src/Products/PloneMeeting/tests/testContacts.py
@@ -1132,7 +1132,7 @@ class testContacts(PloneMeetingTestCase):
             only_factory=True)
         self.assertTrue(self.developers_uid in item.Vocabulary('associatedGroups')[0])
         self.assertTrue(self.developers_uid in item.listProposingGroups())
-        self.assertTrue(self.developers_reviewers in item.listCopyGroups())
+        self.assertTrue(self.developers_reviewers in item.Vocabulary('copyGroups')[0])
         self.assertTrue(self.developers_uid in advisers_vocab_factory(item))
         self.assertTrue(self.tool.userIsAmong(['creators']))
         # after deactivation, the group is no more useable...
@@ -1143,7 +1143,7 @@ class testContacts(PloneMeetingTestCase):
         # remove proposingGroup or it will appear in the vocabulary as 'developers' is currently used...
         item.setProposingGroup('')
         self.assertFalse(self.developers_uid in item.listProposingGroups())
-        self.assertFalse(self.developers_reviewers in item.listCopyGroups())
+        self.assertFalse(self.developers_reviewers in item.Vocabulary('copyGroups')[0])
         self.assertFalse(self.developers_uid in advisers_vocab_factory(item))
         self.assertFalse(self.tool.userIsAmong(['creators']))
 

--- a/src/Products/PloneMeeting/vocabularies.zcml
+++ b/src/Products/PloneMeeting/vocabularies.zcml
@@ -21,6 +21,10 @@
            name="Products.PloneMeeting.vocabularies.associatedgroupsvocabulary" />
   <utility component=".vocabularies.ItemAssociatedGroupsVocabularyFactory"
            name="Products.PloneMeeting.vocabularies.itemassociatedgroupsvocabulary" />
+  <utility component=".vocabularies.CopyGroupsVocabularyFactory"
+           name="Products.PloneMeeting.vocabularies.copygroupsvocabulary" />
+  <utility component=".vocabularies.ItemCopyGroupsVocabularyFactory"
+           name="Products.PloneMeeting.vocabularies.itemcopygroupsvocabulary" />
   <utility component=".vocabularies.GroupsInChargeVocabularyFactory"
            name="Products.PloneMeeting.vocabularies.groupsinchargevocabulary" />
   <utility component=".vocabularies.ItemGroupsInChargeVocabularyFactory"


### PR DESCRIPTION
  - Added `Products.PloneMeeting.vocabularies.copygroupsvocabulary` (faceted) and
    `Products.PloneMeeting.vocabularies.itemcopygroupsvocabulary` (MeetingItem) vocabularies
  - moved `MeetingItem.copyGroup` vocabulary from `listCopyGroups` to `Products.PloneMeeting.vocabularies.itemcopygroupsvocabulary`
  - factorized the way advices and copy groups are displayed on item view (`displayAdvisers/displayCopyGroups`)
  - adapted tests accordingly

See #PMSER-54