### PR TITLE
Fixed `DataGridField` data lost for fields using single checkbox and …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,10 @@ Changelog
   inactive because disabled in `MeetingConfig.customAdvisers` but that were
   actually still active because used in `MeetingConfig.selectableAdvisers`.
   [gbastien]
+- Fixed `DataGridField` data lost for fields using single checkbox and multi
+  checkboxes when validation failed.  This was impacting the `MeetingConfig`.
+  Needed to override relevant datagrid templates.
+  [gbastien]
 
 4.2b11 (2021-01-19)
 -------------------

--- a/src/Products/PloneMeeting/skins/plonemeeting_plone/datagrid_checkbox_cell.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_plone/datagrid_checkbox_cell.pt
@@ -1,0 +1,47 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone">
+
+
+<!-- View/edit radio button choice cells -->
+
+<body>
+    <!-- VIEW -->
+    <metal:view_cell_macro define-macro="view_cell">
+      <div style="font-size:120%; line-height:100%;" tal:condition="cell_value">&#10004;</div>
+      <div tal:condition="not:cell_value">-</div>
+    </metal:view_cell_macro>
+
+    <!-- EDIT -->
+    <metal:edit_cell_macro define-macro="edit_cell">
+           <tal:comment replace="nothing">XXX fixed values of checkbox lost upon validation error, get value from request</tal:comment>
+           <input class="noborder"
+                  type="checkbox"
+                  value="1"
+                  tal:define="name string:${fieldName}.${column}.${repeat/rows/number};"
+                  tal:attributes="checked python:rows.get(column) == '1' or request.get(name, '') == '1';
+                                  name name;
+                                  id string:${column}_${fieldId};
+                                  title column_label;
+                                  "/>
+    </metal:edit_cell_macro>
+
+
+   <!-- EMPTY EDIT -->
+    <metal:edit_cell_macro define-macro="edit_empty_cell">
+        <tal:block>
+           <input class="noborder"
+                  type="checkbox"
+                  value="1"
+                  tal:attributes="checked python: column_definition.getDefault(here) == '1';
+                                  name string:${fieldName}.${column}.999999;
+                                  title column_label;"
+                />
+        </tal:block>
+    </metal:edit_cell_macro>
+
+</body>
+
+</html>

--- a/src/Products/PloneMeeting/skins/plonemeeting_plone/datagrid_multiselect_cell.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_plone/datagrid_multiselect_cell.pt
@@ -10,6 +10,7 @@
 <body>
     <!-- VIEW -->
     <metal:view_cell_macro define-macro="view_cell">
+      <tal:comment replace="nothing">XXX adapted to render with "structure"</tal:comment>
       <span tal:content="structure python:context.displayValue(column_definition.getVocabulary(context), cell_value, widget)"></span>
     </metal:view_cell_macro>
 
@@ -21,11 +22,13 @@
                             opt_val python:opt[0];
                             opt_label python:opt[1];
                             ">
+               <tal:comment replace="nothing">XXX fixed values of checkboxes lost upon validation error, get value from request</tal:comment>
                <input class="noborder" type="checkbox" value="1" id="" style="width: auto;"
-                      tal:attributes="name string:${fieldName}.${column}.${opt_val}.${repeat/rows/number};
+                      tal:define="name string:${fieldName}.${column}.${opt_val}.${repeat/rows/number};"
+                      tal:attributes="name name;
                                       id string:${fieldName}_${column}_${opt_val}_${repeat/rows/number}_${opt_index};
                                       title column_label|nothing;
-                                      checked python:opt_val in rows.get(column, []) and 'checked' or False;
+                                      checked python:(opt_val in rows.get(column, []) or '1' in request.get(name, [])) and 'checked' or False;
                                       "/>
                <label for="" tal:attributes="for string:${fieldName}_${column}_${opt_val}_${repeat/rows/number}_${opt_index}"
                              tal:content="opt_label"></label>


### PR DESCRIPTION
…multi checkboxes when validation failed.  This was impacting the `MeetingConfig`. Needed to override relevant datagrid templates.

See #PM-3398