### PR TITLE
Display the `?` icon next to copy groups on the item view in green...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -316,6 +316,9 @@ Changelog
   `natsort.realsorted` that behaves better with numbered categories
   (`1 Cat1`, `1.1 Cat1.1`, ...).
   [gbastien]
+- Display the `?` icon next to copy groups on the item view in green when copy
+  groups have actually access to the item, in classic grey color otherwise.
+  [gbastien]
 
 4.2b11 (2021-01-19)
 -------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -3127,6 +3127,12 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             allGroups += tuple(self.autoCopyGroups)
         return allGroups
 
+    def check_copy_groups_have_access(self):
+        """Return True if copyGroups have access in current review_state."""
+        tool = api.portal.get_tool('portal_plonemeeting')
+        cfg = tool.getMeetingConfig(self)
+        return self.query_state() in cfg.getItemCopyGroupsStates()
+
     security.declarePublic('checkPrivacyViewable')
 
     def checkPrivacyViewable(self):

--- a/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_view.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_view.pt
@@ -139,19 +139,22 @@
             </div>
 
             <tal:comment replace="nothing">Copy groups for this item</tal:comment>
-            <div class="discreet" tal:condition="context/isCopiesEnabled"
-                                  tal:define="copyGroups context/getAllCopyGroups;">
-                <span class="item_attribute_label"
-                      i18n:translate="PloneMeeting_label_copyGroups"></span>
-                <span class='fa fa-question-circle help-doc pmHelp'
-                      i18n:attributes="title"
-                      tal:attributes="title python: context.getCopyGroupsHelpMsg(meetingConfig)">
-                </span>:&nbsp;&nbsp;
-                <tal:displayCopyGroups condition="copyGroups">
-                    <span tal:replace="structure context/displayCopyGroups">Copy groups</span>
-                </tal:displayCopyGroups>
-                <span tal:condition="not: copyGroups">-</span>
-            </div>
+            <tal:copyGroups condition="python: context.isCopiesEnabled()">
+                <div class="discreet" tal:define="copyGroups python: context.getAllCopyGroups();
+                                                  copy_groups_have_access python: context.check_copy_groups_have_access();">
+                    <span class="item_attribute_label"
+                          i18n:translate="PloneMeeting_label_copyGroups"></span>
+                    <span tal:define="css_class string:fa fa-question-circle help-doc pmHelp"
+                          i18n:attributes="title"
+                          tal:attributes="title python: context.getCopyGroupsHelpMsg(meetingConfig);
+                                          class python: css_class + (copy_groups_have_access and ' green-colored' or '');">
+                    </span>:&nbsp;&nbsp;
+                    <tal:displayCopyGroups condition="copyGroups">
+                        <span tal:replace="structure context/displayCopyGroups">Copy groups</span>
+                    </tal:displayCopyGroups>
+                    <span tal:condition="not: copyGroups">-</span>
+                </div>
+            </tal:copyGroups>
 
             <tal:comment replace="nothing">Item is signed?</tal:comment>
             <div class="discreet"


### PR DESCRIPTION
When copy groups have actually access to the item, in classic grey color otherwise.

See #PM-3447