### PR TITLE
Added parameter `isUserIds` to `utils.sendMailIfRelevant`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,10 @@ Changelog
 
 - Fixed an issue in `_migrateItemPredecessorReference` when migrating to 4200.
   [aduchene]
-
+- Added parameter `isUserIds` to `utils.sendMailIfRelevant` so it is possible
+  to send an e-mail to arbitrary users.
+  Renamed parameter `permissionOrSuffixOrRoleOrGroupIds` to `value`.
+  [gbastien]
 
 4.2b13 (2021-07-16)
 -------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -4544,7 +4544,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         if plone_group_ids:
             params = {"obj": self,
                       "event": "adviceToGive",
-                      "permissionOrSuffixOrRoleOrGroupIds": plone_group_ids,
+                      "value": plone_group_ids,
                       "isGroupIds": True,
                       "debug": debug}
             return sendMailIfRelevant(**params)


### PR DESCRIPTION
So it is possible to send an e-mail to arbitrary users. Renamed parameter `permissionOrSuffixOrRoleOrGroupIds` to `value`.

See #MPMSPII-4
