### PR TITLE
While hidding history link on item to the `powerobservers` (when using field `MeetingConfig.hideHistoryTo`), do not hide history if current user is `powerobserver` and member of the item proposing group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ Changelog
   return the raw value by default instead the output that is treated by
   `portal_transforms`, as the `PMTextAreaField` contains plain text, it is useless.
   [gbastien]
+- While hidding history link on item to the `powerobservers` (when using field
+  `MeetingConfig.hideHistoryTo`), do not hide history if current user is
+  `powerobserver` and member of the item proposing group.
+  [gbastien]
 
 4.2b13 (2021-07-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ Changelog
   return the raw value by default instead the output that is treated by
   `portal_transforms`, as the `PMTextAreaField` contains plain text, it is useless.
   [gbastien]
+- Fixed the default item empty template that was not respecting the
+  `MeetingItem.templateUsingGroups` parameter, it is now possible to restrict
+  the default item empty template to some groups.
+  [gbastien]
 - While hidding history link on item to the `powerobservers` (when using field
   `MeetingConfig.hideHistoryTo`), do not hide history if current user is
   `powerobserver` and member of the item proposing group.

--- a/src/Products/PloneMeeting/browser/overrides.py
+++ b/src/Products/PloneMeeting/browser/overrides.py
@@ -1497,13 +1497,21 @@ class PMContentHistoryView(IHContentHistoryView):
         """Override to take MeetingConfig.hideHistoryTo into account."""
         res = super(PMContentHistoryView, self).show_history()
         if res:
+            # if history shown, check MeetingConfig.hideHistoryTo
+            # only if current user is not member of proposingGroup
             tool = api.portal.get_tool('portal_plonemeeting')
             cfg = tool.getMeetingConfig(self.context)
             hideHistoryTo = cfg.getHideHistoryTo()
-            for power_observer_type in hideHistoryTo:
-                if tool.isPowerObserverForCfg(cfg, power_observer_type=power_observer_type):
-                    res = False
-                    break
+            if hideHistoryTo:
+                item_review_state = self.context.query_state()
+                proposing_group = self.context._getGroupManagingItem(
+                    item_review_state, theObject=False)
+                if proposing_group not in tool.get_orgs_for_user(the_objects=False):
+                    for power_observer_type in hideHistoryTo:
+                        if tool.isPowerObserverForCfg(
+                           cfg, power_observer_type=power_observer_type):
+                            res = False
+                            break
         return res
 
 

--- a/src/Products/PloneMeeting/tests/testViews.py
+++ b/src/Products/PloneMeeting/tests/testViews.py
@@ -2499,6 +2499,28 @@ class testViews(PloneMeetingTestCase):
             meeting.get_signatures().split("\n")[1]
         )
 
+    def test_pm_show_history(self):
+        """Test the contenthistory.show_history() that will depend on
+           MeetingConfig.hideHistoryTo parameter."""
+        self._setPowerObserverStates(states=(self._stateMappingFor('itemcreated'),))
+        self.changeUser('pmCreator1')
+        item = self.create("MeetingItem")
+        contenthistory = getMultiAdapter(
+            (item, self.request), name='contenthistory')
+        self.assertTrue(contenthistory.show_history())
+        self.changeUser('powerobserver1')
+        self.assertTrue(self.hasPermission(View, item))
+        self.assertTrue(contenthistory.show_history())
+
+        # now configure so powerobservers may not access history
+        self.meetingConfig.setHideHistoryTo(('powerobservers', ))
+        self.assertFalse(contenthistory.show_history())
+
+        # when power observer is also member of the item proposingGroup
+        # then he has access to the item history
+        self._addPrincipalToGroup(self.member.getId(), self.developers_creators)
+        self.assertTrue(contenthistory.show_history())
+
 
 def test_suite():
     from unittest import makeSuite


### PR DESCRIPTION
See #SUP-19748
