### PR TITLE
Added parameter `MeetingConfig.computeItemReferenceForItemsOutOfMeeting`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ Changelog
   Now item reference is updated when item inserted/removed from a meeting but also
   when back to validated and for transitions deciding out of meeting.
   [gbastien]
+- Added helper method `Meeting.is_late` and use it everywhere necessary.
+  [gbastien]
 
 4.2b13 (2021-07-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,11 @@ Changelog
 - For field `MeetingCategory.category_mapping_when_cloning_to_other_mc`, display
   also disabled categories in vocabulary so it is visible on category view.
   [gbastien]
+- Added parameter `MeetingConfig.computeItemReferenceForItemsOutOfMeeting` to
+  enable computation of item reference for items decided out of meeting.
+  Now item reference is updated when item inserted/removed from a meeting but also
+  when back to validated and for transitions deciding out of meeting.
+  [gbastien]
 
 4.2b13 (2021-07-16)
 -------------------

--- a/src/Products/PloneMeeting/MeetingConfig.py
+++ b/src/Products/PloneMeeting/MeetingConfig.py
@@ -633,6 +633,20 @@ schema = Schema((
         write_permission="PloneMeeting: Write risky config",
     ),
     BooleanField(
+        name='computeItemReferenceForItemsOutOfMeeting',
+        default=defValues.computeItemReferenceForItemsOutOfMeeting,
+        widget=BooleanField._properties['widget'](
+            description="ComputeItemReferenceForItemsOutOfMeeting",
+            description_msgid="compute_item_reference_for_items_out_of_meeting_descr",
+            label='Computeitemreferenceforitemsoutofmeeting',
+            label_msgid='PloneMeeting_label_computeItemReferenceForItemsOutOfMeeting',
+            i18n_domain='PloneMeeting',
+        ),
+        schemata="data",
+        write_permission="PloneMeeting: Write risky config",
+    ),
+
+    BooleanField(
         name='enableLabels',
         default=defValues.enableLabels,
         widget=BooleanField._properties['widget'](

--- a/src/Products/PloneMeeting/browser/templates/header_item.pt
+++ b/src/Products/PloneMeeting/browser/templates/header_item.pt
@@ -1,10 +1,14 @@
 <h1 class="documentFirstHeading" i18n:domain="PloneMeeting">
     <span tal:content="structure context/getPrettyLink">Pretty title</span>
-    <tal:itemRef define="itemNumber python: context.getItemNumber(relativeTo='meeting', for_display=True)"
+    <tal:itemRef define="itemNumber python: context.getItemNumber(relativeTo='meeting', for_display=True);
+                         itemReference python: context.getItemReference();"
                  condition="python: context.adapted().mustShowItemReference()">
         <br />
-        <span class="discreet" tal:condition="python: itemNumber != None"
-                               tal:content="python: str(itemNumber) + '.'"></span>
-        <span class="discreet" tal:content="context/getItemReference"></span>
+        <span class="discreet"
+              tal:condition="nocall:itemNumber"
+              tal:content="python: str(itemNumber) + '.'"></span>
+        <span class="discreet"
+              tal:condition="nocall:itemReference"
+              tal:content="python:itemReference"></span>
     </tal:itemRef>
 </h1>

--- a/src/Products/PloneMeeting/browser/viewlets.py
+++ b/src/Products/PloneMeeting/browser/viewlets.py
@@ -10,7 +10,6 @@ from plone.app.layout.viewlets import ViewletBase
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.PloneMeeting.events import _is_held_pos_uid_used_by
 from Products.PloneMeeting.utils import displaying_available_items
-from Products.PloneMeeting.utils import get_states_before
 from zope.component import getMultiAdapter
 
 
@@ -24,8 +23,7 @@ class ForceInsertNormal(ViewletBase):
 
     def enabled(self):
         """Is the checkbox enabled?  Only necessary if meeting is in a late state."""
-        late_state = self.context.adapted().get_late_state()
-        return self.context.query_state() not in get_states_before(self.context, late_state)
+        return self.context.is_late()
 
     def render(self):
         if self.available():

--- a/src/Products/PloneMeeting/content/meeting.py
+++ b/src/Products/PloneMeeting/content/meeting.py
@@ -1090,7 +1090,7 @@ class Meeting(Container):
            It is the case if the review_state is after the late state.'''
         meeting_state = self.query_state()
         late_state = self.adapted().get_late_state()
-        return meeting_state not in get_states_before(self, late_state)
+        return late_state and meeting_state not in get_states_before(self, late_state)
 
     def _available_items_query(self):
         '''Check docstring in IMeeting.'''

--- a/src/Products/PloneMeeting/content/meeting.py
+++ b/src/Products/PloneMeeting/content/meeting.py
@@ -1085,6 +1085,12 @@ class Meeting(Container):
         kwargs["additional_catalog_query"] = additional_catalog_query
         return self.get_items(ordered=ordered, **kwargs)
 
+    def is_late(self):
+        ''' '''
+        meeting_state = self.query_state()
+        late_state = self.adapted().get_late_state()
+        return meeting_state not in get_states_before(self, late_state)
+
     def _available_items_query(self):
         '''Check docstring in IMeeting.'''
         tool = api.portal.get_tool('portal_plonemeeting')
@@ -1104,8 +1110,7 @@ class Meeting(Container):
                ]
 
         # before late state, accept items having any preferred meeting
-        late_state = self.adapted().get_late_state()
-        if meeting_state in get_states_before(self, late_state):
+        if not self.is_late():
             # get items for which the preferred_meeting_date is lower or
             # equal to the date of this meeting (self)
             # a no preferred meeting item preferred_meeting_date is 1950/01/01

--- a/src/Products/PloneMeeting/content/meeting.py
+++ b/src/Products/PloneMeeting/content/meeting.py
@@ -1086,7 +1086,8 @@ class Meeting(Container):
         return self.get_items(ordered=ordered, **kwargs)
 
     def is_late(self):
-        ''' '''
+        '''Is meeting considered late?
+           It is the case if the review_state is after the late state.'''
         meeting_state = self.query_state()
         late_state = self.adapted().get_late_state()
         return meeting_state not in get_states_before(self, late_state)

--- a/src/Products/PloneMeeting/interfaces.py
+++ b/src/Products/PloneMeeting/interfaces.py
@@ -185,7 +185,9 @@ class IMeetingItemDocumentation:
        ArchGenXML 2, we document the provided methods in this absurd class.'''
     def mustShowItemReference():
         '''When must I show the item reference ? In the default implementation,
-           item references are shown as soon as a meeting is published.'''
+           item references are shown as soon as a meeting is frozen or when
+           an item is out of a meeting but has a reference (case when using
+           workflowAdaptation "accepted_out_of_meeting" for example).'''
     def get_predecessors():
         '''Returns the entire chain of predecessors and successors.'''
     def addRecurringItemToMeeting(meeting):

--- a/src/Products/PloneMeeting/profiles/__init__.py
+++ b/src/Products/PloneMeeting/profiles/__init__.py
@@ -527,6 +527,7 @@ class MeetingConfigDescriptor(Descriptor):
         self.itemReferenceFormat = "python: 'Ref. ' + (here.hasMeeting() and " \
             "here.restrictedTraverse('@@pm_unrestricted_methods').getLinkedMeetingDate().strftime('%Y%m%d') or '') " \
             "+ '/' + str(here.getItemNumber(relativeTo='meeting', for_display=True))"
+        self.computeItemReferenceForItemsOutOfMeeting = False
         self.enableLabels = False
         # labels are like :
         # {'read': {'color': 'blue', 'label_id': 'read', 'by_user': True, 'title': 'Read'},

--- a/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingconfig_view.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingconfig_view.pt
@@ -341,10 +341,12 @@
           <td tal:define="field python:here.getField('itemReferenceFormat')">
             <span metal:use-macro="here/widgets/field/macros/view" />
           </td>
+          <td tal:define="field python:here.getField('computeItemReferenceForItemsOutOfMeeting')">
+            <span metal:use-macro="here/widgets/field/macros/view" />
+          </td>
           <td tal:define="field python:here.getField('enableLabels')">
             <span metal:use-macro="here/widgets/field/macros/view" />
           </td>
-          <td></td>
         </tr>
         <tr valign="top">
           <td tal:define="field python:here.getField('toDiscussSetOnItemInsert')">

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -2955,11 +2955,10 @@ class testMeetingItem(PloneMeetingTestCase):
         self.validateItem(lateItem)
         # for now, it is considered as late
         self.failUnless(lateItem.wfConditions().isLateFor(meeting))
-        late_state = meeting.adapted().get_late_state()
         for tr in self.TRANSITIONS_FOR_CLOSING_MEETING_2:
             if tr in self.transitions(meeting):
                 self.do(meeting, tr)
-            if meeting.query_state() not in get_states_before(meeting, late_state):
+            if meeting.is_late():
                 self.failUnless(lateItem.wfConditions().isLateFor(meeting))
             else:
                 self.failIf(lateItem.wfConditions().isLateFor(meeting))


### PR DESCRIPTION
To enable computation of item reference for items decided out of meeting. Now item reference is updated when item inserted/removed from a meeting but also when back to validated and for transitions deciding out of meeting.

See #PM-3099