### PR TITLE
Rely on `archetypes.schematuning` (thought it was already the case).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 4.2b20 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Rely on `archetypes.schematuning` (thought it was already the case).
+  [gbastien]
+- Fixed `monkey.validate` (load `monkey` in tests so it is taken into account).
+  [gbastien]
 
 4.2b19 (2021-11-08)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(name='Products.PloneMeeting',
                           amqp=[]),
       install_requires=[
           'appy > 0.8.0',
+          'archetypes.schematuning',
           'beautifulsoup4',
           'natsort',
           'setuptools',

--- a/src/Products/PloneMeeting/__init__.py
+++ b/src/Products/PloneMeeting/__init__.py
@@ -58,7 +58,6 @@ def initialize(context):
     """initialize product (called by zope)"""
 
     from Products.PloneMeeting import monkey
-
     import Meeting
     import MeetingCategory
     import MeetingConfig

--- a/src/Products/PloneMeeting/monkey.py
+++ b/src/Products/PloneMeeting/monkey.py
@@ -86,7 +86,7 @@ def validate(self, REQUEST=None, errors=None, data=None, metadata=None):
     """Monkeypatch to log errors because sometimes, when errors occur in multiple
        or on disabled fields, it is not visible into the UI."""
     errors = self.__old_pm_validate(REQUEST, errors, data, metadata)
-    if errors and api.user.get_current(REQUEST).has_role('Manager'):
+    if errors and api.user.get_current().has_role('Manager'):
         logger.info(errors)
     return errors
 

--- a/src/Products/PloneMeeting/testing.py
+++ b/src/Products/PloneMeeting/testing.py
@@ -7,6 +7,10 @@
 # GNU General Public License (GPL)
 #
 
+
+import monkey # noqa
+
+
 from plone import api
 from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
 from plone.app.testing import FunctionalTesting
@@ -56,8 +60,8 @@ PM_Z2 = z2.IntegrationTesting(bases=(z2.STARTUP, PM_ZCML),
 PM_TESTING_PROFILE = PMLayer(
     zcml_filename="testing.zcml",
     zcml_package=Products.PloneMeeting,
-    additional_z2_products=('collective.eeafaceted.collectionwidget',
-                            'Products.PloneMeeting',
+    additional_z2_products=('Products.PloneMeeting',
+                            'collective.eeafaceted.collectionwidget',
                             'Products.CMFPlacefulWorkflow',
                             'Products.PasswordStrength'),
     gs_profile_id='Products.PloneMeeting:testing',

--- a/src/Products/PloneMeeting/tests/testMeetingConfig.py
+++ b/src/Products/PloneMeeting/tests/testMeetingConfig.py
@@ -67,13 +67,19 @@ class testMeetingConfig(PloneMeetingTestCase):
     def test_pm_Validate_shortName(self):
         '''Test the MeetingConfig.shortName validate method.
            This validates that the shortName is unique across every MeetingConfigs.'''
+        self.changeUser("siteadmin")
         cfg = self.meetingConfig
         cfg2Name = self.meetingConfig2.getShortName()
         # can validate it's own shortName
         self.assertFalse(cfg.validate_shortName(cfg.getShortName()))
         # can validate an unknown shortName
         self.assertFalse(cfg.validate_shortName('other-short-name'))
-        self.assertTrue(cfg.validate_shortName(cfg2Name) == DUPLICATE_SHORT_NAME % cfg2Name)
+        self.assertEqual(cfg.validate_shortName(cfg2Name),
+                         DUPLICATE_SHORT_NAME % cfg2Name)
+        # test the validate method as it is monkeypatched
+        self.request.form["shortName"] = cfg2Name
+        self.assertEqual(cfg.validate(REQUEST=self.request, data=self.request.form),
+                         {"shortName": DUPLICATE_SHORT_NAME % cfg2Name})
 
     def test_pm_Validate_customAdvisersSameRowIdForDifferentRows(self):
         '''This validates that there can not be several rows having same 'row_id'.


### PR DESCRIPTION
Fixed `monkey.validate` (load `monkey` in tests so it is taken into account).
See #PM-3768