### PR TITLE
Use `pm_technical_index` to store item initiators to speed up removal of unused `held_position` or `organization` (before it was necessary to walk and wake up every items).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 4.2b24 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Use `pm_technical_index` to store item initiators to speed up removal of
+  unused `held_position` or `organization` (before it was necessary to walk
+  and wake up every items).
+  [gbastien]
 
 4.2b23 (2022-01-04)
 -------------------

--- a/src/Products/PloneMeeting/browser/templates/viewlet_held_position_back_refs.pt
+++ b/src/Products/PloneMeeting/browser/templates/viewlet_held_position_back_refs.pt
@@ -1,15 +1,33 @@
-<div id="held_position_back_refs" i18n:domain="PloneMeeting">
+<div id="held_position_back_refs" i18n:domain="PloneMeeting"
+     tal:define="using_configs python: view.using_configs();
+                 using_meetings python: view.using_meetings();
+                 using_items python: view.using_items();">
   <h3><span i18n:translate="">Used by following contents</span> :</h3>
-  <h5><span i18n:translate="">Filled in the "Ordered contacts" for meeting configurations</span> :</h5>
-  <ul tal:repeat="cfg view/using_configs">
+  <h5><span i18n:translate="">Filled in the "Ordered contacts" for meeting configurations</span>&nbsp;:</h5>
+  <ul tal:repeat="cfg using_configs">
     <li><a tal:attributes="href string:${cfg/absolute_url}/?pageName=assembly_and_signatures;" tal:content="python: cfg.Title(include_config_group=True)">Meeting config title</a></li>
   </ul>
-  <h5><span i18n:translate="">Used in the assembly for meetings</span> :</h5>
-  <ul tal:repeat="infos python: view.using_meetings().items()">
+  <span class="discreet" i18n:translate="None" tal:condition="not:nocall:using_configs">None</span>
+  <h5><span i18n:translate="">Used in the assembly for meetings</span>&nbsp;:</h5>
+  <ul tal:repeat="infos python: using_meetings.items()">
     <li><h5 tal:content="python: infos[0].Title(include_config_group=True)">Meeting config title</h5></li>
     <ul>
-     <li tal:repeat="meeting python: infos[1]"><a tal:attributes="href meeting/absolute_url;" tal:content="meeting/Title">Meeting title</a></li>
+     <li tal:repeat="meeting python: infos[1]">
+        <a tal:attributes="href meeting/absolute_url;" tal:content="meeting/Title">Meeting title</a></li>
      <li>...</li>
     </ul>
   </ul>
+  <span class="discreet" i18n:translate="None" tal:condition="not:nocall:using_meetings">None</span>
+  <h5><span i18n:translate="">Used as item initiator for items</span>&nbsp;:</h5>
+  <ul tal:repeat="infos python: using_items.items()">
+    <li><h5 tal:content="python: infos[0].Title(include_config_group=True)">Meeting config title</h5></li>
+    <ul>
+     <li tal:repeat="item_brain python: infos[1]">
+        <a tal:attributes="href python: item_brain.getURL();"
+           tal:content="python: item_brain.Title">Item title</a></li>
+     <li>...</li>
+    </ul>
+  </ul>
+  <span class="discreet" i18n:translate="None" tal:condition="not:nocall:using_items">None</span>
+
 </div>

--- a/src/Products/PloneMeeting/config.py
+++ b/src/Products/PloneMeeting/config.py
@@ -381,6 +381,8 @@ FACETED_ANNEXES_CRITERION_ID = 'c20'
 
 # name of marker specifyng that a reindex is required
 REINDEX_NEEDED_MARKER = "_catalog_reindex_needed"
+# prefix used in pm_technical_index to store item initiators
+ITEM_INITIATOR_INDEX_PATTERN = "item_initiator_{0}"
 
 
 def registerClasses():

--- a/src/Products/PloneMeeting/indexes.py
+++ b/src/Products/PloneMeeting/indexes.py
@@ -20,6 +20,7 @@ from plone.indexer import indexer
 from Products.PloneMeeting.config import ALL_ADVISERS_GROUP_VALUE
 from Products.PloneMeeting.config import EMPTY_STRING
 from Products.PloneMeeting.config import HIDDEN_DURING_REDACTION_ADVICE_VALUE
+from Products.PloneMeeting.config import ITEM_INITIATOR_INDEX_PATTERN
 from Products.PloneMeeting.config import ITEM_NO_PREFERRED_MEETING_VALUE
 from Products.PloneMeeting.config import NOT_GIVEN_ADVICE_VALUE
 from Products.PloneMeeting.config import REINDEX_NEEDED_MARKER
@@ -98,11 +99,16 @@ def pm_technical_index(obj):
     """
     This index is made to hold various technical informations:
     - "reindex_needed" is used to know if a reindex must occurs during night tasks;
+    - "item_initiator_..." will hold MeetingItem.itemInititors values to ease
+      removing a held_position that is not used;
     - ...
     """
     res = []
     if base_getattr(obj, REINDEX_NEEDED_MARKER, False):
         res.append(REINDEX_NEEDED_MARKER)
+    if obj.__class__.__name__ == "MeetingItem":
+        for hp_uid in obj.getItemInitiator():
+            res.append(ITEM_INITIATOR_INDEX_PATTERN.format(hp_uid))
     return res or _marker
 
 

--- a/src/Products/PloneMeeting/monkey.py
+++ b/src/Products/PloneMeeting/monkey.py
@@ -1,5 +1,6 @@
 
 from Acquisition import aq_base
+from cPickle import dumps
 from imio.helpers.cache import get_cachekey_volatile
 from imio.helpers.security import fplog
 from plone import api
@@ -23,7 +24,6 @@ from types import StringType
 from z3c.form import interfaces
 from z3c.form.widget import SequenceWidget
 from zope.ramcache.ram import Storage
-from cPickle import dumps
 
 
 def _patched_equal(context, row):

--- a/src/Products/PloneMeeting/skins/plonemeeting_plone/base_edit.cpt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_plone/base_edit.cpt
@@ -18,7 +18,7 @@ to use <fieldset> in the edit form.
                    fieldsets python: [fieldset for fieldset in schematas.keys() if fieldset not in ['metadata', 'settings']];
                    default_fieldset python:'default' in fieldsets and 'default' or fieldsets and fieldsets[0] or None;
                    fieldset request/fieldset|options/fieldset|default_fieldset;
-                   fields python: context.Schemata()['default'].fields();
+                   fields python: [field for field in context.Schema().fields() if field.schemata in fieldsets];
                    dummy python:context.at_isEditable(fields);
                    portal_type python:context.meta_type in ['MeetingItem',] and context.meta_type.lower() or context.getPortalTypeName().lower().replace(' ', '_');
                    portal_url nocall:context/portal_url;


### PR DESCRIPTION
See #PM-3788
