### PR TITLE
Enable `display_below_content_title_on_views` and `display_photo_label_on_views` in `collective.contact.core` registry parameters.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Changelog
   This solves the `MeetingItem.internalNotes` editable forever that was no more
   editable when meeting was closed.
   [gbastien]
+- Enable `display_below_content_title_on_views` and `display_photo_label_on_views`
+  in `collective.contact.core` registry parameters.
+  [gbastien]
 
 4.2rc6 (2022-01-27)
 -------------------

--- a/src/Products/PloneMeeting/profiles/default/registry.xml
+++ b/src/Products/PloneMeeting/profiles/default/registry.xml
@@ -5,6 +5,12 @@
     <record name="collective.contact.core.interfaces.IContactCoreParameters.display_contact_photo_on_organization_view">
         <value>False</value>
     </record>
+    <record name="collective.contact.core.interfaces.IContactCoreParameters.display_below_content_title_on_views">
+        <value>True</value>
+    </record>
+    <record name="collective.contact.core.interfaces.IContactCoreParameters.display_photo_label_on_views">
+        <value>True</value>
+    </record>
 
     <records interface="plone.app.querystring.interfaces.IQueryField"
              prefix="plone.app.querystring.field.meeting_date">


### PR DESCRIPTION
See #PM-3826