### PR TITLE
Fixed annex type icon wronlgy displayed on meeting view to users not able to access confidential annexes. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
   [gbastien]
 - Display `global_actions` on the advice view.
   [gbastien]
+- Fixed annex type icon wronlgy displayed on meeting view to users not able to
+  access confidential annexes. The confidential annexes were not downloadable
+  but the annex type icon was display and on hover, the `tooltipster` was empty.
+  [gbastien]
 
 4.2rc23 (2022-05-03)
 --------------------

--- a/src/Products/PloneMeeting/adapters.py
+++ b/src/Products/PloneMeeting/adapters.py
@@ -1582,7 +1582,10 @@ class PMCategorizedObjectInfoAdapter(CategorizedObjectInfoAdapter):
     def _apply_visible_groups_security(self, group_ids):
         """Compute 'View' permission if annex is confidential,
            apply local_roles and give 'View' to 'AnnexReader' either,
-           remove every local_roles and acquire 'View'."""
+           remove every local_roles and acquire 'View'.
+           WE DO NOT apply this on Meeting because of the possibility to select
+           "every _creators groups" and it is not possible to give the
+           'AnnexReader' role to all these _creators groups."""
         if self.parent.getTagName() == 'MeetingItem' or \
            self.parent.portal_type in self.tool.getAdvicePortalTypeIds():
             # reinitialize permissions in case no more confidential

--- a/src/Products/PloneMeeting/browser/templates/display_annexes.pt
+++ b/src/Products/PloneMeeting/browser/templates/display_annexes.pt
@@ -1,5 +1,5 @@
 <tal:annexes condition="view/show">
-  <fieldset tal:define="annexes python: context.unrestrictedTraverse('@@categorized-childs')(portal_type=view.annex_portal_type).strip();"
+  <fieldset tal:define="annexes python: context.unrestrictedTraverse('@@categorized-childs')(portal_type=view.annex_portal_type, check_can_view=view.check_can_view).strip();"
             tal:attributes="class string:section_${view/annex_portal_type}">
       <legend i18n:domain="PloneMeeting" i18n:translate="" tal:content="view/fieldset_legend">Annexes</legend>
       <table width="100%" class="no-style-table" cellpadding="0" cellspacing="0" style="margin: 0;">

--- a/src/Products/PloneMeeting/browser/templates/meeting_view.pt
+++ b/src/Products/PloneMeeting/browser/templates/meeting_view.pt
@@ -163,7 +163,7 @@
             class="auto-height"
             style="width: 100%; padding-bottom: 1em;">
     </iframe>
-    
+
     <script>
         $('iframe.auto-height').iFrameResize({log:false, scrolling:false, heightCalculationMethod:'lowestElement'})
     </script>
@@ -202,7 +202,7 @@
   </div>
 
   <tal:comment replace="nothing">Annexes</tal:comment>
-  <tal:annexes replace="structure context/@@display-annexes" />
+  <tal:annexes replace="structure python: context.restrictedTraverse('@@display-annexes')(check_can_view=True)" />
   <div class="separator"></div>
 
   <tal:comment replace="nothing">Parameters</tal:comment>

--- a/src/Products/PloneMeeting/browser/views.py
+++ b/src/Products/PloneMeeting/browser/views.py
@@ -2140,10 +2140,14 @@ class DisplayAnnexesView(BrowserView):
         self.tool = api.portal.get_tool('portal_plonemeeting')
         self.portal_url = api.portal.get().absolute_url()
 
-    def __call__(self, annex_portal_type='annex', fieldset_legend="annexes"):
+    def __call__(self,
+                 annex_portal_type='annex',
+                 fieldset_legend="annexes",
+                 check_can_view=False):
         """ """
         self.annex_portal_type = annex_portal_type
         self.fieldset_legend = fieldset_legend
+        self.check_can_view = check_can_view
         return self.index()
 
     def show(self):


### PR DESCRIPTION
The confidential annexes were not downloadable but the annex type icon was display and on hover, the `tooltipster` was empty.

See #PM-3890