### PR TITLE
Turned `adaptations.WAITING_ADVICES_FROM_STATES` value `use_custom_transition_title_for` from a tuple of transitions ids to a dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ Changelog
   access confidential annexes. The confidential annexes were not downloadable
   but the annex type icon was display and on hover, the `tooltipster` was empty.
   [gbastien]
+- Turned `adaptations.WAITING_ADVICES_FROM_STATES` value
+  `use_custom_transition_title_for` from a tuple of transitions ids to a dict
+  so it is possible to define an arbitrary new custom title for the transition,
+  before it was taking the transition id, now it is possible to override several
+  different transition title for same transition id in different workflows.
+  [gbastien]
 
 4.2rc23 (2022-05-03)
 --------------------

--- a/src/Products/PloneMeeting/columns.py
+++ b/src/Products/PloneMeeting/columns.py
@@ -212,6 +212,7 @@ class PMPrettyLinkColumn(PrettyLinkColumn):
         elif obj.getTagName() == 'Meeting':
             visibleColumns = cfg.getMeetingColumns()
             staticInfos = obj.restrictedTraverse('@@static-infos')(visibleColumns=visibleColumns)
+            # check_can_view=True because permission check is not enough
             annexes += obj.restrictedTraverse('@@categorized-childs')(
                 portal_type='annex', check_can_view=True)
             # display number of items in meeting title

--- a/src/Products/PloneMeeting/model/adaptations.py
+++ b/src/Products/PloneMeeting/model/adaptations.py
@@ -59,7 +59,7 @@ WAITING_ADVICES_FROM_STATES = {
          # if () given, a custom transition icon is used for every back transitions
          'only_use_custom_back_transition_icon_for': ("validated", ),
          'use_custom_state_title': True,
-         'use_custom_transition_title_for': (),
+         'use_custom_transition_title_for': {},
          'remove_modify_access': True,
          'adviser_may_validate': False,
          # must end with _waiting_advices
@@ -78,7 +78,7 @@ WAITING_ADVICES_FROM_STATES = {
          # if () given, a custom transition icon is used for every back transitions
          'only_use_custom_back_transition_icon_for': ("validated", ),
          'use_custom_state_title': True,
-         'use_custom_transition_title_for': (),
+         'use_custom_transition_title_for': {},
          'remove_modify_access': True,
          'adviser_may_validate': False,
          # must end with _waiting_advices
@@ -873,8 +873,8 @@ def _performWorkflowAdaptations(meetingConfig, logger=logger):
                         if infos.get('use_custom_icon', False):
                             icon_name = from_transition_id
                         tr_title = 'wait_advices_from'
-                        if from_transition_id in infos.get('use_custom_transition_title_for', ()):
-                            tr_title = from_transition_id
+                        if from_transition_id in infos.get('use_custom_transition_title_for', {}):
+                            tr_title = infos['use_custom_transition_title_for'][from_transition_id]
                         transition.setProperties(
                             title=tr_title,
                             new_state_id=new_state_id, trigger_type=1, script_name='',


### PR DESCRIPTION
So it is possible to define an arbitrary new custom title for the transition, before it was taking the transition id, now it is possible to override several different transition title for same transition id in different workflows.

See #PM-3885