### PR TITLE
Manage `MeetingConfig.defaultAdviceHiddenDuringRedaction` when a new …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,9 @@ Changelog
 - Changed from 90° to 270° image rotation in `BaseDGHV.image_orientation` because it is
   rotated clockwise with imagemagick, in pod templates including annexes.
   [aduchene]
-- Manage `MeetingConfig.defaultAdviceHiddenDuringRedaction` only when a new advice is added,
-  not when advice is asked_again, see https://support.imio.be/browse/PM-3883.
+- Manage `MeetingConfig.defaultAdviceHiddenDuringRedaction` when a new advice is added,
+  and when advice is asked_again the same way (in the edit form) and display a message
+  to the adviser.
   [gbastien]
 - Display `global_actions` on the advice view.
   [gbastien]

--- a/src/Products/PloneMeeting/browser/advices.py
+++ b/src/Products/PloneMeeting/browser/advices.py
@@ -456,6 +456,15 @@ class AdviceEdit(DefaultEditForm):
         super(AdviceEdit, self).update()
         if not self.actions.executedActions:
             _display_asked_again_warning(self.context, self.context.aq_inner.aq_parent)
+        # check if need to auto hide the advice if it is "asked_again"
+        if self.context.advice_type == 'asked_again' and \
+           self.context.advice_hide_during_redaction is False:
+            tool = api.portal.get_tool('portal_plonemeeting')
+            cfg = tool.getMeetingConfig(self.context)
+            if self.context.portal_type in cfg.getDefaultAdviceHiddenDuringRedaction():
+                api.portal.show_message(_("advice_hide_during_redaction_set_auto_to_true"),
+                                        request=self.request)
+                self.widgets['advice_hide_during_redaction'].value = ['true']
 
 
 def advice_uid_default():

--- a/src/Products/PloneMeeting/content/advice.py
+++ b/src/Products/PloneMeeting/content/advice.py
@@ -99,7 +99,11 @@ def advice_hide_during_redactionDefaultValue(data):
     tool = api.portal.get_tool('portal_plonemeeting')
     cfg = tool.getMeetingConfig(data.context)
     # manage when portal_type accessed from the Dexterity types configuration
-    return cfg and published.ti.id in cfg.getDefaultAdviceHiddenDuringRedaction() or False
+    hidden = cfg and published.ti.id in cfg.getDefaultAdviceHiddenDuringRedaction() or False
+    if hidden:
+        api.portal.show_message(_("advice_hide_during_redaction_set_auto_to_true"),
+                                request=data.context.REQUEST)
+    return hidden
 
 
 class MeetingAdvice(Container):

--- a/src/Products/PloneMeeting/tests/testPerformances.py
+++ b/src/Products/PloneMeeting/tests/testPerformances.py
@@ -898,7 +898,7 @@ class testPerformances(PloneMeetingTestCase):
     @timecall
     def _check_permission(self, item, times=1):
         ''' '''
-        pm_logger.info('Call _check_permission {0} times'.format(times))
+        pm_logger.info('Call _checkPermission {0} times'.format(times))
         for time in range(times):
             _checkPermission("ModifyPortalContent", item)
 


### PR DESCRIPTION
…advice is added, and when advice is asked_again the same way (in the edit form) and display a message to the adviser.

See #PM-3883