### PR TITLE
In `MeetingConfig.getMeetingsAcceptingItems`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,18 @@ Changelog
   `getFirstItemNumber/first_item_number` replacement work for any cases,
   not only for `Meeting` POD templates.
   [gbastien]
-- In `Migrate_To_4200._fixPODTemplatesInstructions` manage `display_date` instructions.
+- In `Migrate_To_4200._fixPODTemplatesInstructions` manage `display_date`
+  instructions.
+  [gbastien]
+- In `MeetingConfig.getMeetingsAcceptingItems`, moved the `review_states`
+  computation logic from `MeetingItem.listMeetingsAcceptingItems` to
+  `MeetingConfig._getMeetingsAcceptingItemsQuery` so calling
+  `MeetingConfig.getMeetingsAcceptingItems` will always be correct when
+  `review_states=[]`.
+  This fixes a bug in `imio.pm.ws.soap.soapview.SOAPView._meetingsAcceptingItems`
+  that was returning the same meetings accepting items no matter user was
+  `MeetingManager` or not (was actually always returning meetings accepting items
+  as if user was a `MeetingManager`).
   [gbastien]
 
 4.2rc29 (2022-06-17)

--- a/src/Products/PloneMeeting/MeetingConfig.py
+++ b/src/Products/PloneMeeting/MeetingConfig.py
@@ -7546,7 +7546,10 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
         # he is able to add a meetingitem to a 'decided' meeting.
         # except if we specifically restricted given p_review_states.
         if not review_states:
-            review_states = self.getMeetingStatesAcceptingItemsForMeetingManagers()
+            if self.aq_parent.isManager(self):
+                review_states = self.getMeetingStatesAcceptingItemsForMeetingManagers()
+            else:
+                review_states = self.getItemPreferredMeetingStates()
 
         query = {'portal_type': self.getMeetingTypeName(),
                  'review_state': review_states,
@@ -7559,15 +7562,17 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
 
     def getMeetingsAcceptingItems(self, review_states=[], inTheFuture=False):
         '''Returns meetings accepting items.'''
+        # compute the query so when review_states=[], it is computed and we use
+        # the "review_state" value from the query
+        query = self._getMeetingsAcceptingItemsQuery(review_states, inTheFuture)
         req = self.REQUEST
         key = "PloneMeeting-MeetingConfig-getMeetingsAcceptingItems-{0}-{1}-{2}".format(
-            repr(self), review_states, inTheFuture)
+            self.id, tuple(query['review_state']), inTheFuture)
         cache = IAnnotations(req)
         brains = cache.get(key, None)
 
         if brains is None:
             catalog = api.portal.get_tool('portal_catalog')
-            query = self._getMeetingsAcceptingItemsQuery(review_states, inTheFuture)
             brains = catalog.unrestrictedSearchResults(**query)
             cache[key] = brains
         return brains

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -3421,12 +3421,9 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         tool = api.portal.get_tool('portal_plonemeeting')
         cfg = tool.getMeetingConfig(self)
 
-        if tool.isManager(cfg):
-            meeting_states_accepting_items = cfg.getMeetingStatesAcceptingItemsForMeetingManagers()
-        else:
-            meeting_states_accepting_items = cfg.getItemPreferredMeetingStates()
-
-        for meetingBrain in cfg.getMeetingsAcceptingItems(review_states=meeting_states_accepting_items):
+        # while passing empty review_states, it is computed depending
+        # on fact that current user isManager or not
+        for meetingBrain in cfg.getMeetingsAcceptingItems(review_states=[]):
             meetingDate = tool.format_date(meetingBrain.meeting_date, with_hour=True)
             meetingState = translate(meetingBrain.review_state,
                                      domain="plone",

--- a/src/Products/PloneMeeting/tests/PloneMeetingTestCase.py
+++ b/src/Products/PloneMeeting/tests/PloneMeetingTestCase.py
@@ -243,10 +243,11 @@ class PloneMeetingTestCase(unittest.TestCase, PloneMeetingTestingHelpers):
             res = sm.checkPermission(permission, obj)
         return res
 
-    def changeUser(self, loginName):
+    def changeUser(self, loginName, clean_memoize=True):
         '''Logs out currently logged user and logs in p_loginName.'''
         logout()
-        self.cleanMemoize()
+        if clean_memoize:
+            self.cleanMemoize()
         if loginName == 'admin':
             login(self.app, loginName)
         else:
@@ -584,10 +585,11 @@ class PloneMeetingTestCase(unittest.TestCase, PloneMeetingTestingHelpers):
             self._addPrincipalToGroup(member.getId(), group)
 
     # Workflow-related methods -------------------------------------------------
-    def do(self, obj, transition, comment=''):
+    def do(self, obj, transition, comment='', clean_memoize=True):
         '''Executes a workflow p_transition on a given p_obj.'''
         self.wfTool.doActionFor(obj, transition, comment=comment)
-        self.cleanMemoize()
+        if clean_memoize:
+            self.cleanMemoize()
 
     def transitions(self, obj):
         '''Returns the list of transition ids that the current user

--- a/src/Products/PloneMeeting/tests/helpers.py
+++ b/src/Products/PloneMeeting/tests/helpers.py
@@ -190,7 +190,7 @@ class PloneMeetingTestingHelpers:
             return getattr(
                 self, ('TRANSITIONS_FOR_PROPOSING_ITEM_%d' % meetingConfigNumber))
 
-    def proposeItem(self, item, first_level=False, as_manager=True):
+    def proposeItem(self, item, first_level=False, as_manager=True, clean_memoize=True):
         '''Propose passed p_item using TRANSITIONS_FOR_PROPOSING_ITEM_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_PROPOSING_ITEM_x is 1 or 2.
@@ -198,9 +198,10 @@ class PloneMeetingTestingHelpers:
            this makes it possible to reach an intermediate propose level.'''
         self._doTransitionsFor(item,
                                self.get_transitions_for_proposing_item(first_level),
-                               as_manager=as_manager)
+                               as_manager=as_manager,
+                               clean_memoize=clean_memoize)
 
-    def prevalidateItem(self, item, as_manager=True):
+    def prevalidateItem(self, item, as_manager=True, clean_memoize=True):
         '''Prevalidate passed p_item using TRANSITIONS_FOR_PREVALIDATING_ITEM_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_PREVALIDATING_ITEM_x is 1 or 2.'''
@@ -208,9 +209,10 @@ class PloneMeetingTestingHelpers:
         self._doTransitionsFor(
             item,
             getattr(self, ('TRANSITIONS_FOR_PREVALIDATING_ITEM_%d' % meetingConfigNumber)),
-            as_manager=as_manager)
+            as_manager=as_manager,
+            clean_memoize=clean_memoize)
 
-    def validateItem(self, item, as_manager=True):
+    def validateItem(self, item, as_manager=True, clean_memoize=True):
         '''Validate passed p_item using TRANSITIONS_FOR_VALIDATING_ITEM_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_VALIDATING_ITEM_x is 1 or 2.'''
@@ -218,9 +220,10 @@ class PloneMeetingTestingHelpers:
         self._doTransitionsFor(
             item,
             getattr(self, ('TRANSITIONS_FOR_VALIDATING_ITEM_%d' % meetingConfigNumber)),
-            as_manager=as_manager)
+            as_manager=as_manager,
+            clean_memoize=clean_memoize)
 
-    def presentItem(self, item, as_manager=True):
+    def presentItem(self, item, as_manager=True, clean_memoize=True):
         '''Present passed p_item using TRANSITIONS_FOR_PRESENTING_ITEM_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_PRESENTING_ITEM_x is 1 or 2.'''
@@ -228,9 +231,10 @@ class PloneMeetingTestingHelpers:
         self._doTransitionsFor(
             item,
             getattr(self, ('TRANSITIONS_FOR_PRESENTING_ITEM_%d' % meetingConfigNumber)),
-            as_manager=as_manager)
+            as_manager=as_manager,
+            clean_memoize=clean_memoize)
 
-    def publishMeeting(self, meeting, as_manager=False):
+    def publishMeeting(self, meeting, as_manager=False, clean_memoize=True):
         '''Publish passed p_meeting using TRANSITIONS_FOR_PUBLISHING_MEETING_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_PUBLISHING_MEETING_x is 1 or 2.'''
@@ -238,9 +242,10 @@ class PloneMeetingTestingHelpers:
         self._doTransitionsFor(
             meeting,
             getattr(self, ('TRANSITIONS_FOR_PUBLISHING_MEETING_%d' % meetingConfigNumber)),
-            as_manager=as_manager)
+            as_manager=as_manager,
+            clean_memoize=clean_memoize)
 
-    def freezeMeeting(self, meeting, as_manager=False):
+    def freezeMeeting(self, meeting, as_manager=False, clean_memoize=True):
         '''Freeze passed p_meeting using TRANSITIONS_FOR_FREEZING_MEETING_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_FREEZING_MEETING_x is 1 or 2.'''
@@ -248,9 +253,10 @@ class PloneMeetingTestingHelpers:
         self._doTransitionsFor(
             meeting,
             getattr(self, ('TRANSITIONS_FOR_FREEZING_MEETING_%d' % meetingConfigNumber)),
-            as_manager=as_manager)
+            as_manager=as_manager,
+            clean_memoize=clean_memoize)
 
-    def decideMeeting(self, meeting, as_manager=False):
+    def decideMeeting(self, meeting, as_manager=False, clean_memoize=True):
         '''Decide passed p_meeting using TRANSITIONS_FOR_DECIDING_MEETING_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_DECIDING_MEETING_x is 1 or 2.'''
@@ -258,9 +264,10 @@ class PloneMeetingTestingHelpers:
         self._doTransitionsFor(
             meeting,
             getattr(self, ('TRANSITIONS_FOR_DECIDING_MEETING_%d' % meetingConfigNumber)),
-            as_manager=as_manager)
+            as_manager=as_manager,
+            clean_memoize=clean_memoize)
 
-    def closeMeeting(self, meeting, as_manager=False):
+    def closeMeeting(self, meeting, as_manager=False, clean_memoize=True):
         '''Close passed p_meeting using TRANSITIONS_FOR_CLOSING_MEETING_x.
            The p_meetingConfigNumber specify if we use meetingConfig or meetingConfig2, so
            the _x here above in TRANSITIONS_FOR_CLOSING_MEETING_x is 1 or 2.'''
@@ -268,7 +275,8 @@ class PloneMeetingTestingHelpers:
         self._doTransitionsFor(
             meeting,
             getattr(self, ('TRANSITIONS_FOR_CLOSING_MEETING_%d' % meetingConfigNumber)),
-            as_manager=as_manager)
+            as_manager=as_manager,
+            clean_memoize=clean_memoize)
 
     def backToState(self, itemOrMeeting, state, as_manager=True, comment=""):
         """Set the p_item back to p_state.
@@ -302,17 +310,17 @@ class PloneMeetingTestingHelpers:
         if as_manager:
             self.changeUser(currentUser)
 
-    def _doTransitionsFor(self, itemOrMeeting, transitions, as_manager=False, comment=""):
+    def _doTransitionsFor(self, itemOrMeeting, transitions, as_manager=False, comment="", clean_memoize=True):
         """Helper that just trigger given p_transitions on given p_itemOrMeeting."""
         # do things as admin to avoid permission issues
         if as_manager:
             currentUser = self.member.getId()
-            self.changeUser('admin')
+            self.changeUser('admin', clean_memoize=clean_memoize)
         for tr in transitions:
             if tr in self.transitions(itemOrMeeting):
-                self.do(itemOrMeeting, tr, comment=comment)
+                self.do(itemOrMeeting, tr, comment=comment, clean_memoize=clean_memoize)
         if as_manager:
-            self.changeUser(currentUser)
+            self.changeUser(currentUser, clean_memoize=clean_memoize)
 
     def _determinateUsedMeetingConfigNumber(self):
         """Helper method that check if we use meetingConfig or meetingConfig2."""


### PR DESCRIPTION
Moved the `review_states` computation logic from `MeetingItem.listMeetingsAcceptingItems` to `MeetingConfig._getMeetingsAcceptingItemsQuery` so calling `MeetingConfig.getMeetingsAcceptingItems` will always be correct when `review_states=[]`.

This fixes a bug in `imio.pm.ws.soap.soapview.SOAPView._meetingsAcceptingItems` that was returning the same meetings accepting items no matter user was `MeetingManager` or not (was actually always returning meetings accepting items as if user was a `MeetingManager`).
See #MOD-903