### PR TITLE
Cleaned `UnrestrictedMethodsView`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,12 @@ Changelog
   delay aware adviser config if it was never used and to change the
   `for_item_created_from` if it is not an auto asked advice.
   [gbastien]
+- Cleaned `UnrestrictedMethodsView`, splitted it to `ItemUnrestrictedMethodsView`
+  and `MeetingUnrestrictedMethodsView` because the `findFirstItemNumberForMeeting`
+  method is the only one called with a `Meeting` as context and others need a
+  `MeetingItem` as context.
+  Renamed `findFirstItemNumberForMeeting` to `findFirstItemNumber`.
+  [gbastien]
 
 4.2rc29 (2022-06-17)
 --------------------

--- a/src/Products/PloneMeeting/Meeting.py
+++ b/src/Products/PloneMeeting/Meeting.py
@@ -241,7 +241,7 @@ class MeetingWorkflowActions(object):
         # Set the firstItemNumber
         unrestrictedMethodsView = getMultiAdapter((self.context, self.context.REQUEST),
                                                   name='pm_unrestricted_methods')
-        self.context.setFirstItemNumber(unrestrictedMethodsView.findFirstItemNumberForMeeting(self.context))
+        self.context.setFirstItemNumber(unrestrictedMethodsView.findFirstItemNumber(self.context))
         self.context.updateItemReferences()
         # remove annex previews of every items if relevant
         if self.cfg.getRemoveAnnexesPreviewsOnMeetingClosure():

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -3141,9 +3141,8 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
                 # we call findBaseNumberRelativeToMeetingConfig, see docstring there
                 # call the view on meeting because it is memoized and for example in meeting_view
                 # the meeting does not change but the item does
-                unrestrictedMethodsView = getMultiAdapter((meeting, self.REQUEST),
-                                                          name='pm_unrestricted_methods')
-                currentMeetingComputedFirstNumber = unrestrictedMethodsView.findFirstItemNumberForMeeting(meeting)
+                view = getMultiAdapter((meeting, self.REQUEST), name='pm_unrestricted_methods')
+                currentMeetingComputedFirstNumber = view.findFirstItemNumber()
                 # now that we have the currentMeetingComputedFirstNumber, that is
                 # the theorical current meeting first number, we can compute current item
                 # number that is this number + current item number relativeTo the meeting - 1

--- a/src/Products/PloneMeeting/browser/configure.zcml
+++ b/src/Products/PloneMeeting/browser/configure.zcml
@@ -834,15 +834,22 @@
         layer="Products.PloneMeeting.interfaces.IPloneMeetingLayer"
         permission="zope2.View" />
 
-    <!-- this view will contains some methods doing unrestricted things.  It replaces Manager Proxy roled python Scripts -->
+    <!-- this view will contains some methods doing unrestricted things.
+         It replaces Manager Proxy roled python Scripts -->
     <browser:page
-        for="*"
+        for="Products.PloneMeeting.interfaces.IMeetingItem"
         name="pm_unrestricted_methods"
-        class=".views_unrestricted.UnrestrictedMethodsView"
+        class=".views_unrestricted.ItemUnrestrictedMethodsView"
         layer="Products.PloneMeeting.interfaces.IPloneMeetingLayer"
         allowed_attributes="getLinkedMeetingTitle
-                            getLinkedMeetingDate
-                            findFirstItemNumberForMeeting"
+                            getLinkedMeetingDate"
+        permission="zope2.View" />
+    <browser:page
+        for="Products.PloneMeeting.content.meeting.IMeeting"
+        name="pm_unrestricted_methods"
+        class=".views_unrestricted.MeetingUnrestrictedMethodsView"
+        layer="Products.PloneMeeting.interfaces.IPloneMeetingLayer"
+        allowed_attributes="findFirstItemNumber"
         permission="zope2.View" />
 
     <browser:page

--- a/src/Products/PloneMeeting/browser/views_unrestricted.py
+++ b/src/Products/PloneMeeting/browser/views_unrestricted.py
@@ -7,7 +7,7 @@ from zope.component import getMultiAdapter
 from zope.i18n import translate
 
 
-class UnrestrictedMethodsView(BrowserView):
+class ItemUnrestrictedMethodsView(BrowserView):
     """
       This class contains every methods behaving as unrestricted.
       These methods were formerly Manager proxy roled python Scripts.
@@ -29,8 +29,11 @@ class UnrestrictedMethodsView(BrowserView):
         if meeting:
             return meeting.date
 
+
+class MeetingUnrestrictedMethodsView(BrowserView):
+
     @memoize
-    def findFirstItemNumberForMeeting(self, meeting):
+    def findFirstItemNumber(self):
         """
           Return the base number to take into account while computing an item number.
           This is used when given p_meeting firstItemNumber is -1, we need to look in previous
@@ -46,7 +49,7 @@ class UnrestrictedMethodsView(BrowserView):
         # could be unaccessible to the current user, for example by default a
         # meeting in state 'created' is not viewable by items creators
         brains = catalog.unrestrictedSearchResults(portal_type=cfg.getMeetingTypeName(),
-                                                   meeting_date={'query': meeting.date,
+                                                   meeting_date={'query': self.context.date,
                                                                  'range': 'max'},
                                                    sort_on='meeting_date',
                                                    sort_order='reverse')

--- a/src/Products/PloneMeeting/tests/testMeeting.py
+++ b/src/Products/PloneMeeting/tests/testMeeting.py
@@ -2956,7 +2956,7 @@ class testMeetingType(PloneMeetingTestCase):
 
         # all normal numbered items
         unrestricted_view = meeting3.restrictedTraverse('@@pm_unrestricted_methods')
-        self.assertEqual(unrestricted_view.findFirstItemNumberForMeeting(meeting3), 15)
+        self.assertEqual(unrestricted_view.findFirstItemNumber(), 15)
 
         # put some subnumbers for meeting1
         meeting1_item2 = meeting1.get_items(ordered=True)[1]
@@ -2967,10 +2967,10 @@ class testMeetingType(PloneMeetingTestCase):
         change_order_view('number', '5.1')
         self.assertEqual([item.getItemNumber() for item in meeting1.get_items(ordered=True)],
                          [100, 101, 200, 300, 400, 500, 501])
-        # call to 'findFirstItemNumberForMeeting' is memoized
+        # call to 'findFirstItemNumber' is memoized
         self.cleanMemoize()
         # now meeting1 last number is considered 5
-        self.assertEqual(unrestricted_view.findFirstItemNumberForMeeting(meeting3), 13)
+        self.assertEqual(unrestricted_view.findFirstItemNumber(), 13)
 
     def test_pm_FirstItemNumberSetOnClose(self):
         """First item number is set on closure if it was still -1,

--- a/src/Products/PloneMeeting/workflows/meeting.py
+++ b/src/Products/PloneMeeting/workflows/meeting.py
@@ -170,7 +170,7 @@ class MeetingWorkflowActions(object):
                                                name='pm_unrestricted_methods')
         if self.context.first_item_number == -1:
             self.context.first_item_number = \
-                unrestricted_methods.findFirstItemNumberForMeeting(self.context)
+                unrestricted_methods.findFirstItemNumber()
             self.context.update_item_references()
         # remove annex previews of every items if relevant
         if self.cfg.getRemoveAnnexesPreviewsOnMeetingClosure():


### PR DESCRIPTION
Splitted it to `ItemUnrestrictedMethodsView` and `MeetingUnrestrictedMethodsView` because the `findFirstItemNumberForMeeting` method is the only one called with a `Meeting` as context and others need a `MeetingItem` as context. Renamed `findFirstItemNumberForMeeting` to `findFirstItemNumber`.

See #PM-3923