### PR TITLE
Make MeetingManager bypass `MeetingCategory.using_groups` check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,12 @@ Changelog
   `MeetingItem` as context.
   Renamed `findFirstItemNumberForMeeting` to `findFirstItemNumber`.
   [gbastien]
+- Make MeetingManager bypass `MeetingCategory.using_groups` check when cloning
+  an item, this way we avoid problems with category not selectable by
+  `MeetingManager` leading to items not cloned (recurring items, delayed items, ...).
+  Added `MeetingItem.get_successor` helper that will return the last
+  (and very often only) successor.
+  [gbastien]
 
 4.2rc29 (2022-06-17)
 --------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -3211,12 +3211,25 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             safe_delattr(self, 'linked_predecessor_path')
             safe_delattr(self, 'linked_successor_uids')
 
-    def get_successors(self, the_objects=True, unrestricted=True):
-        ''' '''
+    def get_successor(self, the_objects=True, unrestricted=True):
+        """Shortcut to get the last successors that should be the official successor."""
+        # we force ordered=True for get_successors to make sure the last successor
+        # is the last chronologically created
+        successors = self.get_successors(
+            the_objects=the_objects, ordered=True, unrestricted=unrestricted)
+        return successors and successors[-1] or None
+
+    def get_successors(self, the_objects=True, ordered=True, unrestricted=True):
+        '''Return the successors, so the items that were automatically linked to self.
+           Most of times, there will be one single successor, but it may happen
+           that several successors exist, for example when item delayed then corrected
+           then delayed again, most of time one of the 2 successors will be deleted
+           but it is not always the case...'''
         res = getattr(self, 'linked_successor_uids', [])
         if res and the_objects:
             # res is a PersistentList, not working with catalog query
-            res = uuidsToObjects(uuids=tuple(res), unrestricted=unrestricted)
+            # searching successors ordered will make sure that items are returned chronologically
+            res = uuidsToObjects(uuids=tuple(res), ordered=ordered, unrestricted=unrestricted)
         return res
 
     def get_every_successors(obj, the_objects=True, unrestricted=True):

--- a/src/Products/PloneMeeting/content/category.py
+++ b/src/Products/PloneMeeting/content/category.py
@@ -129,7 +129,7 @@ class MeetingCategory(Item):
 
     security.declarePublic('is_selectable')
 
-    def is_selectable(self, userId):
+    def is_selectable(self, userId, ignore_using_groups=False):
         '''Check if category may be used :
            - enabled;
            - current user in using_groups or current user is Manager.'''
@@ -137,7 +137,10 @@ class MeetingCategory(Item):
         # If we have using_groups make sure userId is creator for one of it
         selectable = self.enabled
         cfg = tool.getMeetingConfig(self)
-        if selectable and self.get_using_groups() and not tool.isManager(realManagers=True):
+        # check using_groups if relevant
+        if selectable and \
+           (not ignore_using_groups and self.get_using_groups()) and \
+           not tool.isManager(realManagers=True):
             selectable_org_uids = tool.get_selectable_orgs(cfg, user_id=userId, the_objects=False)
             # Check intersection between self.usingGroups and org uids for which
             # the current user is creator

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -1412,7 +1412,7 @@ class testMeetingItem(PloneMeetingTestCase):
         # do this as 'Manager' in case 'MeetingManager' can not delete the item in used item workflow
         self.deleteAsManager(newItem.UID())
         originalItem.cloneToOtherMeetingConfig(self.meetingConfig2.getId())
-        newItem = originalItem.get_successors()[0]
+        newItem = originalItem.get_successor()
         self.assertEqual(newItem.getCategory(), catIdOfMC2Mapped)
 
     def test_pm_SendItemToOtherMCManually(self):
@@ -4335,7 +4335,7 @@ class testMeetingItem(PloneMeetingTestCase):
         self.assertTrue(self.catalog(SearchableText='delayed'))
         # if the item was duplicated (often the case when delaying an item), the duplicated
         # item keep the original decision
-        duplicatedItem = item2.get_successors()[0]
+        duplicatedItem = item2.get_successor()
         # right duplicated item
         self.assertEqual(duplicatedItem.get_predecessor(), item2)
         self.assertEqual(duplicatedItem.getDecision(), originalDecision)
@@ -8099,6 +8099,27 @@ class testMeetingItem(PloneMeetingTestCase):
         item.setClassifier('classifier1')
         self.assertEqual(item.getClassifier(), 'classifier1')
         self.assertEqual(item.getClassifier(theObject=True), cfg.classifiers.classifier1)
+
+    def test_pm_GetSucessor(self):
+        """Test that MeetingItem.get_successor will always return the last successor."""
+        self.changeUser('pmCreator1')
+        item = self.create('MeetingItem')
+        new_item1 = item.clone(setCurrentAsPredecessor=True)
+        new_item2 = item.clone(setCurrentAsPredecessor=True)
+        new_item3 = item.clone(setCurrentAsPredecessor=True)
+        new_item21 = new_item2.clone(setCurrentAsPredecessor=True)
+        new_item22 = new_item2.clone(setCurrentAsPredecessor=True)
+        new_item31 = new_item3.clone(setCurrentAsPredecessor=True)
+        self.assertEqual(item.get_successor(), new_item3)
+        self.assertEqual(new_item2.get_successor(), new_item22)
+        self.assertEqual(new_item3.get_successor(), new_item31)
+        self.assertIsNone(new_item21.get_successor())
+        self.assertIsNone(new_item22.get_successor())
+        self.assertIsNone(new_item31.get_successor())
+        # every successors will get successors of successors
+        self.assertEqual(item.get_every_successors(),
+                         [new_item1, new_item2, new_item21, new_item22,
+                          new_item3, new_item31])
 
 
 def test_suite():

--- a/src/Products/PloneMeeting/tests/testWFAdaptations.py
+++ b/src/Products/PloneMeeting/tests/testWFAdaptations.py
@@ -2636,7 +2636,7 @@ class testWFAdaptations(PloneMeetingTestCase):
         self.decideMeeting(meeting)
         self.do(item, 'postpone_next_meeting')
         # duplicated and duplicated item is validated
-        clonedItem = item.get_successors()[0]
+        clonedItem = item.get_successor()
         self.assertEqual(clonedItem.get_predecessor(), item)
         self.assertEqual(clonedItem.query_state(), 'validated')
         # optional and automatic given advices were inherited
@@ -2666,7 +2666,7 @@ class testWFAdaptations(PloneMeetingTestCase):
         self.decideMeeting(meeting)
         self.do(item, 'postpone_next_meeting')
         # duplicated and duplicated item is validated
-        clonedItem = item.get_successors()[0]
+        clonedItem = item.get_successor()
         self.assertEqual(clonedItem.get_predecessor(), item)
         self.assertEqual(clonedItem.query_state(), 'validated')
 
@@ -2721,7 +2721,7 @@ class testWFAdaptations(PloneMeetingTestCase):
             self.assertEqual(item.get_successors(the_objects=False), [])
         else:
             # item was duplicated and new item is in it's initial state
-            linked_item = item.get_successors()[0]
+            linked_item = item.get_successor()
             self.assertEqual(linked_item.query_state(), self._initial_state(linked_item))
 
         if additional_wf_transitions:
@@ -2981,7 +2981,7 @@ class testWFAdaptations(PloneMeetingTestCase):
             wfas.append('accepted_out_of_meeting_and_duplicated')
             self._activate_wfas(wfas)
             self.do(item, 'accept_out_of_meeting')
-            duplicated_item = item.get_successors()[0]
+            duplicated_item = item.get_successor()
             self.assertEqual(duplicated_item.get_predecessor(), item)
             self.assertEqual(duplicated_item.query_state(), 'validated')
             # duplicated_item is not more isAcceptableOutOfMeeting
@@ -3047,7 +3047,7 @@ class testWFAdaptations(PloneMeetingTestCase):
             wfas.append('accepted_out_of_meeting_emergency_and_duplicated')
             self._activate_wfas(wfas)
             self.do(item, 'accept_out_of_meeting_emergency')
-            duplicated_item = item.get_successors()[0]
+            duplicated_item = item.get_successor()
             self.assertEqual(duplicated_item.get_predecessor(), item)
             self.assertEqual(duplicated_item.query_state(), 'validated')
             # duplicated_item emergency is no more asked
@@ -3113,7 +3113,7 @@ class testWFAdaptations(PloneMeetingTestCase):
             wfas.append('transfered_and_duplicated')
             self._activate_wfas(wfas)
             self.do(item, 'transfer')
-            duplicated_item = item.get_successors()[0]
+            duplicated_item = item.get_successor()
             self.assertEqual(duplicated_item.get_predecessor(), item)
             self.assertEqual(duplicated_item.query_state(), 'validated')
 


### PR DESCRIPTION
when cloning an item, this way we avoid problems with category not selectable by `MeetingManager` leading to items not cloned (recurring items, delayed items, ...). Added `MeetingItem.get_successor` helper that will return the last (and very often only) successor.

See #PM-3918