### PR TITLE
Added `Meeting.update_first_item_number`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,16 @@ Changelog
 4.2rc31 (unreleased)
 --------------------
 
-- Nothing changed yet.
-
+- Added `Meeting.update_first_item_number` that will manage updating first item
+  number of the meeting.  This way the method is callable from a TAL expression
+  and we may use it when necessary.
+  Moreover, the parameter `get_items_additional_catalog_query={}` will let manage
+  cases where items to take into account are not every items but only a subset
+  of items.
+  [gbastien]
+- Added `safe_utils.set_dx_value` that will let set a value for a DX content
+  attribute from a `RestrictedPython` call.
+  [gbastien]
 
 4.2rc30 (2022-07-01)
 --------------------

--- a/src/Products/PloneMeeting/browser/views_unrestricted.py
+++ b/src/Products/PloneMeeting/browser/views_unrestricted.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from AccessControl import Unauthorized
 from plone import api
 from plone.memoize.view import memoize
 from Products.Five import BrowserView
+from Products.PloneMeeting.browser.itemchangeorder import _is_integer
 from Products.PloneMeeting.utils import notifyModifiedAndReindex
 from zope.component import getMultiAdapter
 from zope.i18n import translate
@@ -32,8 +35,7 @@ class ItemUnrestrictedMethodsView(BrowserView):
 
 class MeetingUnrestrictedMethodsView(BrowserView):
 
-    @memoize
-    def findFirstItemNumber(self):
+    def findFirstItemNumber(self, get_items_additional_catalog_query={}):
         """
           Return the base number to take into account while computing an item number.
           This is used when given p_meeting firstItemNumber is -1, we need to look in previous
@@ -69,9 +71,13 @@ class MeetingUnrestrictedMethodsView(BrowserView):
             # and we continue to the previous meeting
             # divide lastItem itemNumber by 100 so we are sure to ignore subnumbers
             # 308 will become 3 or 1400 will become 14
-            items = meeting.get_items(the_objects=False, ordered=True, unrestricted=True)
-            item = items and items[-1]._unrestrictedGetObject()
-            lastItemNumber = item and item.getItemNumber() / 100 or 0
+            items = meeting.get_items(
+                the_objects=True,
+                ordered=True,
+                unrestricted=True,
+                additional_catalog_query=get_items_additional_catalog_query)
+            # compute number of items ignoring items with a subnumber
+            lastItemNumber = len([item for item in items if _is_integer(item.getItemNumber())])
             numberOfItemsBefore += lastItemNumber
             if not meeting.first_item_number == -1:
                 previousFirstItemNumber = meeting.first_item_number

--- a/src/Products/PloneMeeting/content/meeting.py
+++ b/src/Products/PloneMeeting/content/meeting.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import ClassSecurityInfo
+from AccessControl import Unauthorized
 from collections import OrderedDict
 from collective.behavior.talcondition.utils import _evaluateExpression
 from collective.contact.plonegroup.config import get_registry_organizations
@@ -68,6 +69,7 @@ from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.browser.radio import RadioFieldWidget
 from zope import schema
 from zope.component import adapts
+from zope.component import getMultiAdapter
 from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.i18n import translate
@@ -1886,6 +1888,27 @@ class Meeting(Container):
             delta = cfg.getFreezeDeadlineDefault()
             if not delta.strip() in ('', '0',):
                 self.freeze_deadline = getDateFromDelta(self.date, '-' + delta)
+
+    def update_first_item_number(self,
+                                 update_item_references=True,
+                                 get_items_additional_catalog_query={},
+                                 force=False):
+        """ """
+        # only update if still the initial value
+        if self.first_item_number == -1 or force:
+            # as this may be applied on a closed meeting, we can not protect the method
+            # with a permission, so we check if user isManager
+            tool = api.portal.get_tool('portal_plonemeeting')
+            cfg = tool.getMeetingConfig(self)
+            if not tool.isManager(cfg):
+                raise Unauthorized
+            unrestricted_methods = getMultiAdapter(
+                (self, self.REQUEST), name='pm_unrestricted_methods')
+            self.first_item_number = \
+                unrestricted_methods.findFirstItemNumber(
+                    get_items_additional_catalog_query=get_items_additional_catalog_query)
+            if update_item_references:
+                self.update_item_references()
 
     security.declarePublic('get_user_replacements')
 

--- a/src/Products/PloneMeeting/safe_utils.py
+++ b/src/Products/PloneMeeting/safe_utils.py
@@ -25,5 +25,6 @@ from Products.PloneMeeting.utils import normalize_id
 from Products.PloneMeeting.utils import number_word
 from Products.PloneMeeting.utils import org_id_to_uid
 from Products.PloneMeeting.utils import reindex_object
+from Products.PloneMeeting.utils import set_dx_value
 from Products.PloneMeeting.utils import toHTMLStrikedContent
 from Products.PloneMeeting.utils import uncapitalize

--- a/src/Products/PloneMeeting/tests/testMeeting.py
+++ b/src/Products/PloneMeeting/tests/testMeeting.py
@@ -3893,6 +3893,32 @@ class testMeetingType(PloneMeetingTestCase):
         self.assertEqual(meeting.validation_deadline, datetime(2021, 8, 5, 9, 30))
         self.assertEqual(meeting.freeze_deadline, datetime(2021, 8, 9, 14, 30))
 
+    def test_pm_Update_first_item_number(self):
+        """The the helper Meeting.update_first_item_number that will take in charge"""
+        cfg = self.meetingConfig
+        cfg.setUseGroupsAsCategories(False)
+        self.changeUser('pmManager')
+        meeting1 = self._createMeetingWithItems(meetingDate=datetime(2022, 6, 6))
+        meeting2 = self._createMeetingWithItems()
+        self.assertEqual(meeting1.first_item_number, -1)
+        self.assertEqual(meeting2.first_item_number, -1)
+        self.assertEqual(len(meeting1.get_items()), 5)
+        # update meeting2 then meeting1
+        meeting2.update_first_item_number()
+        self.assertEqual(meeting2.first_item_number, 6)
+        meeting1.update_first_item_number()
+        self.assertEqual(meeting1.first_item_number, 1)
+        # now pass an arbitrary additional query to compute first_item_number
+        # no change for meeting1 as first meeting
+        meeting1.update_first_item_number(
+            get_items_additional_catalog_query={'getCategory': 'development'}, force=True)
+        self.assertEqual(meeting1.first_item_number, 1)
+        # but as there are 2 items using category 'development' for meeting1
+        # the first item number is 3
+        meeting2.update_first_item_number(
+            get_items_additional_catalog_query={'getCategory': 'development'}, force=True)
+        self.assertEqual(meeting2.first_item_number, 3)
+
 
 def test_suite():
     from unittest import makeSuite

--- a/src/Products/PloneMeeting/tests/testUtils.py
+++ b/src/Products/PloneMeeting/tests/testUtils.py
@@ -5,21 +5,25 @@
 # GNU General Public License (GPL)
 #
 
+from AccessControl import Unauthorized
 from collective.contact.plonegroup.utils import get_plone_group
 from imio.helpers.content import richtextval
 from os import path
 from plone.app.controlpanel.events import ConfigurationChangedEvent
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.permissions import View
+from Products.PloneMeeting.config import EXECUTE_EXPR_VALUE
 from Products.PloneMeeting.tests.PloneMeetingTestCase import PloneMeetingTestCase
 from Products.PloneMeeting.utils import duplicate_portal_type
 from Products.PloneMeeting.utils import escape
 from Products.PloneMeeting.utils import org_id_to_uid
 from Products.PloneMeeting.utils import sendMailIfRelevant
+from Products.PloneMeeting.utils import set_dx_value
 from Products.PloneMeeting.utils import set_field_from_ajax
 from Products.PloneMeeting.utils import transformAllRichTextFields
 from Products.PloneMeeting.utils import validate_item_assembly_value
 from zope.event import notify
+from zope.schema._bootstrapinterfaces import WrongType
 
 
 ASSEMBLY_CORRECT_VALUE = u'[[Text]][[Text]]'
@@ -292,6 +296,51 @@ class testUtils(PloneMeetingTestCase):
         self.assertEqual(meeting.observations.raw, text)
         transformAllRichTextFields(meeting, onlyField="observations")
         self.assertEqual(meeting.observations.raw, text)
+
+    def test_pm_Set_dx_value(self):
+        """utils.set_dx_value will set a value on a DX content and check if current
+           user has the permission and if the value does validate."""
+        cfg = self.meetingConfig
+        self._removeConfigObjectsFor(cfg)
+        self.changeUser('pmManager')
+        meeting = self.create('Meeting')
+        # if user able to set, data must validate
+        # here first_item_number needs an integer
+        self.assertEqual(meeting.first_item_number, -1)
+        self.assertRaises(WrongType, set_dx_value, meeting, "first_item_number", "a")
+        set_dx_value(meeting, "first_item_number", 50)
+        self.assertEqual(meeting.first_item_number, 50)
+        # can not do it if does not have the permission
+        self.changeUser('pmCreator1')
+        self.assertTrue(self.hasPermission(View, meeting))
+        self.assertRaises(WrongType, set_dx_value, meeting, "first_item_number", "a")
+        self.assertRaises(Unauthorized, set_dx_value, meeting, "first_item_number", 55)
+        # parameter raise_unauthorized may be False
+        set_dx_value(meeting, "first_item_number", 55, raise_unauthorized=False)
+        # the value is not changed anyway
+        self.assertEqual(meeting.first_item_number, 50)
+        # make sure it is useable in TAL expressions
+        self.changeUser('pmManager')
+        cfg.setOnMeetingTransitionItemActionToExecute(
+            [{'meeting_transition': 'freeze',
+              'item_action': EXECUTE_EXPR_VALUE,
+              'tal_expression':
+                'python: pm_utils.set_dx_value(meeting, "meeting_number", 25)'}, ])
+        self.assertEqual(meeting.meeting_number, -1)
+        self.freezeMeeting(meeting)
+        # if was initialized to "1" by doFreeze but onMeetingTransitionItemActionToExecute
+        # did nothing because it is applied on each items and there are no items!
+        # So when using it to update meeting we really need to make sure the work done
+        # is only done one time
+        self.assertEqual(meeting.meeting_number, 1)
+        # set it back to -1 so we make sure onMeetingTransitionItemActionToExecute
+        # is done after doFreeze
+        meeting.meeting_number = -1
+        self.do(meeting, 'backToCreated')
+        item = self.create('MeetingItem', decision=self.decisionText)
+        self.presentItem(item)
+        self.freezeMeeting(meeting)
+        self.assertEqual(meeting.meeting_number, 25)
 
 
 def test_suite():

--- a/src/Products/PloneMeeting/utils.py
+++ b/src/Products/PloneMeeting/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from AccessControl import Unauthorized
 from AccessControl.Permission import Permission
 from Acquisition import aq_base
 from appy.pod.xhtml2odt import XhtmlPreprocessor
@@ -1007,6 +1008,21 @@ def get_dx_widget(obj, field_name, mode=DISPLAY_MODE):
     # this will set widget.__name__
     locate(widget, None, field_name)
     return widget
+
+
+def set_dx_value(obj, field_name, value, raise_unauthorized=True):
+    """Convenience method to be able to set an attribute on a DX content type."""
+    field = get_dx_field(obj, field_name)
+    if field is not None:
+        # will raise in case an error occurs
+        field.validate(value)
+        schema = get_dx_schema(obj)
+        write_permission = schema.queryTaggedValue(
+            WRITE_PERMISSIONS_KEY, {}).get(field_name, ModifyPortalContent)
+        if _checkPermission(write_permission, obj):
+            field.set(obj, value)
+        elif raise_unauthorized:
+            raise Unauthorized
 
 
 def set_field_from_ajax(obj, field_name, new_value, remember=True, tranform=True, reindex=True, unlock=True):

--- a/src/Products/PloneMeeting/workflows/meeting.py
+++ b/src/Products/PloneMeeting/workflows/meeting.py
@@ -18,7 +18,6 @@ from Products.PloneMeeting.interfaces import IMeetingWorkflowActions
 from Products.PloneMeeting.interfaces import IMeetingWorkflowConditions
 from Products.PloneMeeting.utils import fplog
 from Products.PloneMeeting.utils import get_annexes
-from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import implements
 
@@ -166,12 +165,7 @@ class MeetingWorkflowActions(object):
     def doClose(self, stateChange):
         ''' '''
         # Set the firstItemNumber
-        unrestricted_methods = getMultiAdapter((self.context, self.context.REQUEST),
-                                               name='pm_unrestricted_methods')
-        if self.context.first_item_number == -1:
-            self.context.first_item_number = \
-                unrestricted_methods.findFirstItemNumber()
-            self.context.update_item_references()
+        self.context.update_first_item_number()
         # remove annex previews of every items if relevant
         if self.cfg.getRemoveAnnexesPreviewsOnMeetingClosure():
             # add logging message to fingerpointing log


### PR DESCRIPTION
 that will manage updating first item number of the meeting.  This way the method is callable from a TAL expression and we may use it when necessary. Moreover, the parameter `get_items_additional_catalog_query={}` will let manage cases where items to take into account are not every items but only a subset of items.

Added `safe_utils.set_dx_value` that will let set a value for a DX content attribute from a `RestrictedPython` call.
See #SUP-24646