### PR TITLE
Added `_configurePortalRepository` in `setuphandlers.py` to remove default Plone types that are versionable (`Document`, `Event`, ...)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Changelog
 - Adapted overrided `generationlinks.pt` regarding changes in
   `collective.documentgenerator` (POD templates grouped by title).
   [gbastien]
+- Added `_configurePortalRepository` in `setuphandlers.py` to remove default
+  Plone types that are versionable (`Document`, `Event`, ...).
+  Added upgrade step to 4204.
+  [gbastien]
 
 4.2rc30 (2022-07-01)
 --------------------

--- a/src/Products/PloneMeeting/migrations/migrate_to_4204.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4204.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from Products.PloneMeeting.migrations import logger
+from Products.PloneMeeting.migrations import Migrator
+from Products.PloneMeeting.setuphandlers import _configurePortalRepository
+
+
+class Migrate_To_4204(Migrator):
+
+    def run(self, extra_omitted=[], from_migration_to_4200=False):
+
+        logger.info('Migrating to PloneMeeting 4204...')
+
+        # not necessary if executing the full upgrade to 4200
+        if not from_migration_to_4200:
+            _configurePortalRepository()
+        logger.info('Done.')
+
+
+def migrate(context):
+    '''This migration function will:
+
+       1) Configure portal_repository.
+    '''
+    migrator = Migrate_To_4204(context)
+    migrator.run()
+    migrator.finish()

--- a/src/Products/PloneMeeting/profiles.zcml
+++ b/src/Products/PloneMeeting/profiles.zcml
@@ -154,4 +154,12 @@
       handler="Products.PloneMeeting.migrations.migrate_to_4203.migrate"
       profile="Products.PloneMeeting:default" />
 
+  <genericsetup:upgradeStep
+      title="Go to PloneMeeting 4204"
+      description="Configure portal_repository"
+      source="4203"
+      destination="4204"
+      handler="Products.PloneMeeting.migrations.migrate_to_4204.migrate"
+      profile="Products.PloneMeeting:default" />
+
 </configure>

--- a/src/Products/PloneMeeting/profiles/default/metadata.xml
+++ b/src/Products/PloneMeeting/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4203</version>
+  <version>4204</version>
   <dependencies>
     <dependency>profile-Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow</dependency>
     <dependency>profile-imio.dashboard:default</dependency>

--- a/src/Products/PloneMeeting/setuphandlers.py
+++ b/src/Products/PloneMeeting/setuphandlers.py
@@ -380,6 +380,9 @@ def postInstall(context):
         name='Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.search_rss_enabled',
         value=False)
 
+    # configure portal_repository
+    _configurePortalRepository()
+
     # configure dexterity localrolesfield
     _configureDexterityLocalRolesField()
 
@@ -586,6 +589,18 @@ def _configure_zamqp(site):
         site.portal_setup.runAllImportStepsFromProfile(
             'imio.zamqp.pm:default',
             dependency_strategy=DEPENDENCY_STRATEGY_REAPPLY)
+
+
+def _configurePortalRepository():
+    """Make sure default Plone content type are not versionable."""
+    plone_versioned_types = [u'ATDocument', u'ATNewsItem', u'Document', u'Event', u'Link', u'News Item']
+    pr = api.portal.get_tool('portal_repository')
+    pr.setVersionableContentTypes([pt_id for pt_id in pr.getVersionableContentTypes()
+                                   if pt_id not in plone_versioned_types])
+    for p_type in plone_versioned_types:
+        pr._version_policy_mapping.pop(p_type, None)
+        # _version_policy_mapping is a dict, make change persistent
+        pr._version_policy_mapping = pr._version_policy_mapping
 
 
 def _configureDexterityLocalRolesField():

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -6695,9 +6695,10 @@ class testMeetingItem(PloneMeetingTestCase):
         cfg.setSelectableCopyGroups((self.developers_reviewers, self.vendors_reviewers))
         # make power observers able to see validated items
         self._setPowerObserverStates(states=('validated', ))
-        # by default internalNotes are editable by proposingGroup creators
+        # by default set internalNotes editable by proposingGroup creators
         self._activate_config('itemInternalNotesEditableBy',
-                              'suffix_proposing_group_creators')
+                              'suffix_proposing_group_creators',
+                              keep_existing=False)
 
         def _check(item, view_edit=False):
             view = item.restrictedTraverse('base_view')

--- a/src/Products/PloneMeeting/tests/testSetup.py
+++ b/src/Products/PloneMeeting/tests/testSetup.py
@@ -222,6 +222,14 @@ class testSetup(PloneMeetingTestCase):
         for meeting_type in meeting_types:
             self.failIf(set(meeting_types).difference(factory_types))
 
+    def test_pm_VersionableTypes(self):
+        """Make sure every Plone default types are not more versionable."""
+        portal_repository = api.portal.get_tool('portal_repository')
+        self.assertEqual(portal_repository.getVersionableContentTypes(),
+                         [u'annex', u'annexDecision', u'meetingadvice'])
+        self.assertEqual(sorted(portal_repository._version_policy_mapping.keys()),
+                         [u'annex', u'annexDecision', u'meetingadvice'])
+
     def test_pm_EnsureSolrActivated(self):
         """ """
         pm_logger.info("HAS_SOLR %s" % HAS_SOLR)


### PR DESCRIPTION
 Added upgrade step to 4204.

See #PM-3934