### PR TITLE
Removed field `MeetingConfig.transitionsForPresentingAnItem`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,13 @@ Changelog
 - Added possibility to add images to `MeetingItemTemplate/MeetingItemReccuring`.
   Display the `folder_contents` tab on items of the `MeetingConfig`.
   [gbastien]
+- Added possibility to manage order of attendees by item, this is sometimes
+  necessary when attendee position changed on an item.
+  [gbastien]
+- Removed field `MeetingConfig.transitionsForPresentingAnItem` as information is
+  in `MeetingConfig.itemWFValidationLevels`, method
+  `MeetingConfig.getTransitionsForPresentingAnItem` is kept and does the job.
+  [gbastien]
 
 4.2rc30 (2022-07-01)
 --------------------

--- a/src/Products/PloneMeeting/MeetingConfig.py
+++ b/src/Products/PloneMeeting/MeetingConfig.py
@@ -174,7 +174,6 @@ ITEM_WF_STATE_ATTRS = [
     'itemManualSentToOtherMCStates',
     'recordItemHistoryStates']
 ITEM_WF_TRANSITION_ATTRS = [
-    'transitionsForPresentingAnItem',
     'transitionsReinitializingDelays',
     'transitionsToConfirm',
     'mailItemEvents']
@@ -1239,20 +1238,6 @@ schema = Schema((
         default=defValues.transitionsToConfirm,
         enforceVocabulary=True,
         write_permission="PloneMeeting: Write risky config",
-    ),
-    LinesField(
-        name='transitionsForPresentingAnItem',
-        default=defValues.transitionsForPresentingAnItem,
-        widget=InAndOutWidget(
-            description="TransitionsForPresentingAnItem",
-            description_msgid="transitions_for_presenting_an_item_descr",
-            label='Transitionsforpresentinganitem',
-            label_msgid='PloneMeeting_label_transitionsForPresentingAnItem',
-            i18n_domain='PloneMeeting',
-        ),
-        schemata="workflow",
-        write_permission="PloneMeeting: Write risky config",
-        vocabulary='listEveryItemTransitions',
     ),
     DataGridField(
         name='onTransitionFieldTransforms',
@@ -4050,46 +4035,6 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
         if set(values).difference(usedVoteValues):
             return _('error_next_linked_votes_used_vote_values_must_be_among_used_vote_values')
 
-    security.declarePrivate('validate_transitionsForPresentingAnItem')
-
-    def validate_transitionsForPresentingAnItem(self, values):
-        '''Validate the transitionsForPresentingAnItem field.
-           Check that the given sequence of transition if starting
-           from the item workflow initial_state and ends to the 'presented' state.'''
-        # bypass validation when we are adding a new MeetingConfig thru UI
-        # because some fields are required on different schematas and it does not work...
-        if self.isTemporary():
-            return
-        # we can not specify required=True in the Schema because of InAndOut widget
-        # weird behaviour, so manage required ourselves...
-        if not values or (len(values) == 1 and not values[0]):
-            label = self.Schema()['transitionsForPresentingAnItem'].widget.Label(self)
-            # take classic plone error_required msgid
-            return PloneMessageFactory(u'error_required',
-                                       default=u'${name} is required, please correct.',
-                                       mapping={'name': label})
-        wfTool = api.portal.get_tool('portal_workflow')
-        itemWorkflow = wfTool.getWorkflowsFor(self.getItemTypeName())[0]
-        # first value must be a transition leaving the wf initial_state
-        initialState = itemWorkflow.states[itemWorkflow.initial_state]
-        if not values[0] in initialState.transitions:
-            return _('first_transition_must_leave_wf_initial_state')
-        # now follow given path and check if it result in the 'presented' state
-        # start from the initial_state
-        currentState = initialState
-        for trId in values:
-            # sometimes, an empty '' is in the values?
-            if not trId:
-                continue
-            if trId not in currentState.transitions:
-                return _('given_wf_path_does_not_lead_to_present')
-            transition = itemWorkflow.transitions[trId]
-            # now set current state to the state the transition is resulting to
-            currentState = itemWorkflow.states[transition.new_state_id]
-        # at the end, the currentState must be "presented"
-        if not currentState.id == 'presented':
-            return _('last_transition_must_result_in_presented_state')
-
     security.declarePrivate('validate_powerObservers')
 
     def validate_powerObservers(self, value):
@@ -4885,7 +4830,6 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
         # either using state or transition
         # states
         cfg_item_wf_attrs = list(ITEM_WF_STATE_ATTRS) + list(ITEM_WF_TRANSITION_ATTRS)
-        cfg_item_wf_attrs.remove('transitionsForPresentingAnItem')
         # transitions
         enabled_stored_transitions = self.getItemWFValidationLevels(
             data='leading_transition',
@@ -6758,7 +6702,7 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
 
     def listTransitionsUntilPresented(self):
         '''List available workflow transitions until the 'present' transition included.
-           We base this on the MeetingConfig.transitionsForPresentingAnItem field.
+           We base this on the MeetingConfig.getTransitionsForPresentingAnItem.
            This will let us set an item cloned to another meetingConfig to any state until 'presented'.
            We list every item transitions of every available meetingConfigs.'''
         # we do not use an empty '' but '__nothing__' because of a bug in DataGridField SelectColumn...
@@ -7050,14 +6994,13 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
 
     security.declarePublic('getTransitionsForPresentingAnItem')
 
-    def getTransitionsForPresentingAnItem(self, org_uid=None, **kwargs):
-        '''Overrides field 'transitionsForPresentingAnItem' accessor to be able
-           to pass a p_org_uid, if given, the transitions will be filtered out
-           regarding suffixed Plone groups enabled for it.'''
-        transitions = self.getField('transitionsForPresentingAnItem').get(self, **kwargs)
+    def getTransitionsForPresentingAnItem(self, org_uid=None):
+        '''Return default transitions to present an item.'''
+        item_wf_val_levels = self.getItemWFValidationLevels(only_enabled=True)
+        transitions = [v['leading_transition'] for v in item_wf_val_levels
+                       if v['leading_transition'] != '-'] + ['validate', 'present']
         if org_uid:
             tool = api.portal.get_tool('portal_plonemeeting')
-            item_wf_val_levels = self.getItemWFValidationLevels(only_enabled=True)
             tr_suffixes = {v['leading_transition']: v['suffix'] for v in item_wf_val_levels
                            if v['leading_transition'] != '-'}
             res = []

--- a/src/Products/PloneMeeting/MeetingConfig.py
+++ b/src/Products/PloneMeeting/MeetingConfig.py
@@ -59,7 +59,6 @@ from Products.CMFCore.Expression import Expression
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.permissions import View
 from Products.CMFDynamicViewFTI.browserdefault import BrowserDefaultMixin
-from Products.CMFPlone import PloneMessageFactory
 from Products.CMFPlone.interfaces.constrains import IConstrainTypes
 from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import safe_unicode

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -4524,7 +4524,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         try:
             item.REQUEST.set('PUBLISHED', meeting)
             item.isRecurringItem = True
-            # we use the wf path defined in the cfg.transitionsForPresentingAnItem
+            # we use the wf path defined in the cfg.getTransitionsForPresentingAnItem
             # to present the item to the meeting
             cfg = tool.getMeetingConfig(item)
             # give 'Manager' role to current user to bypass transitions guard

--- a/src/Products/PloneMeeting/migrations/migrate_to_4204.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4204.py
@@ -34,6 +34,8 @@ class Migrate_To_4204(Migrator):
             meeting._p_changed = True
         logger.info('Done.')
 
+
+
     def run(self, extra_omitted=[], from_migration_to_4200=False):
 
         logger.info('Migrating to PloneMeeting 4204...')
@@ -43,6 +45,9 @@ class Migrate_To_4204(Migrator):
             _configurePortalRepository()
             self._reloadItemTemplateAndRecurringTypes()
             self._initMeetingsItemAttendeesOrder()
+
+        # remove field MeetingConfig.transitionsForPresentingAnItem
+        self.cleanMeetingConfigs(field_names=['transitionsForPresentingAnItem'])
         logger.info('Done.')
 
 

--- a/src/Products/PloneMeeting/migrations/migrate_to_4204.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4204.py
@@ -34,8 +34,6 @@ class Migrate_To_4204(Migrator):
             meeting._p_changed = True
         logger.info('Done.')
 
-
-
     def run(self, extra_omitted=[], from_migration_to_4200=False):
 
         logger.info('Migrating to PloneMeeting 4204...')

--- a/src/Products/PloneMeeting/profiles/__init__.py
+++ b/src/Products/PloneMeeting/profiles/__init__.py
@@ -646,7 +646,6 @@ class MeetingConfigDescriptor(Descriptor):
         # button will show a confirmation popup. In this popup, the user will
         # also be able to enter the workflow comment.
         self.transitionsToConfirm = []
-        self.transitionsForPresentingAnItem = ['propose', 'validate', 'present']
         self.onTransitionFieldTransforms = []
         self.onMeetingTransitionItemActionToExecute = []
         self.meetingPresentItemWhenNoCurrentMeetingStates = []

--- a/src/Products/PloneMeeting/profiles/testing/import_data.py
+++ b/src/Products/PloneMeeting/profiles/testing/import_data.py
@@ -288,7 +288,6 @@ meetingPma.usedMeetingAttributes = ('assembly', 'assembly_excused', 'assembly_ab
 meetingPma.maxShownListings = '100'
 meetingPma.workflowAdaptations = ['delayed']
 meetingPma.itemPositiveDecidedStates = ['accepted']
-meetingPma.transitionsForPresentingAnItem = ('propose', 'validate', 'present', )
 meetingPma.onMeetingTransitionItemActionToExecute = (
     {'meeting_transition': 'freeze',
      'item_action': 'itemfreeze',
@@ -418,7 +417,6 @@ meetingPga.annexTypes = [financialAnalysis, legalAnalysis,
                          budgetAnalysisCfg2, itemAnnex, decisionAnnex,
                          adviceAnnex, adviceLegalAnalysis, meetingAnnex]
 meetingPga.usedItemAttributes = ('description', 'toDiscuss', 'associatedGroups', 'itemIsSigned',)
-meetingPga.transitionsForPresentingAnItem = ('propose', 'validate', 'present', )
 meetingPga.onMeetingTransitionItemActionToExecute = deepcopy(
     meetingPma.onMeetingTransitionItemActionToExecute)
 meetingPga.insertingMethodsOnAddItem = ({'insertingMethod': 'on_categories', 'reverse': '0'}, )

--- a/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingconfig_view.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingconfig_view.pt
@@ -742,12 +742,10 @@
           <td tal:define="field python:here.getField('transitionsToConfirm')">
             <span metal:use-macro="here/widgets/field/macros/view" />
           </td>
-          <td tal:define="field python:here.getField('transitionsForPresentingAnItem')">
-            <span metal:use-macro="here/widgets/field/macros/view" />
-          </td>
           <td tal:define="field python:here.getField('onTransitionFieldTransforms')">
             <span metal:use-macro="here/widgets/field/macros/view" />
           </td>
+          <td></td>
         </tr>
         <tr valign="top">
           <td tal:define="field python:here.getField('onMeetingTransitionItemActionToExecute')">

--- a/src/Products/PloneMeeting/tests/testMeetingConfig.py
+++ b/src/Products/PloneMeeting/tests/testMeetingConfig.py
@@ -842,43 +842,6 @@ class testMeetingConfig(PloneMeetingTestCase):
                                        context=self.portal.REQUEST)
         self.assertEqual(cfg.validate_customAdvisers(customAdvisers), can_not_remove_msg)
 
-    def test_pm_Validate_transitionsForPresentingAnItem(self):
-        '''Test the MeetingConfig.transitionsForPresentingAnItem validation.
-           It fails if :
-           - empty, as it is required;
-           - first given transition is not correct;
-           - given sequence is wrong;
-           - last given transition does not result in the 'presented' state.'''
-        cfg = self.meetingConfig
-        # the right sequence is the one defined on self.meetingConfig
-        self.failIf(cfg.validate_transitionsForPresentingAnItem(cfg.getTransitionsForPresentingAnItem()))
-        # if not sequence provided, it fails
-        label = cfg.Schema()['transitionsForPresentingAnItem'].widget.Label(cfg)
-        required_error_msg = PloneMessageFactory(u'error_required',
-                                                 default=u'${name} is required, please correct.',
-                                                 mapping={'name': label})
-        self.assertEqual(cfg.validate_transitionsForPresentingAnItem([]), required_error_msg)
-        # if first provided transition is wrong, it fails with a specific message
-        first_transition_error_msg = _('first_transition_must_leave_wf_initial_state')
-        self.assertEqual(cfg.validate_transitionsForPresentingAnItem(['not_a_transition_leaving_initial_state']),
-                         first_transition_error_msg)
-        # if the given sequence is not right, it fails
-        wrong_sequence_error_msg = _('given_wf_path_does_not_lead_to_present')
-        sequence = list(cfg.getTransitionsForPresentingAnItem())
-        sequence.insert(1, 'wrong_transition')
-        self.assertEqual(cfg.validate_transitionsForPresentingAnItem(sequence), wrong_sequence_error_msg)
-        # XXX for this test, we need at least 2 transitions in the sequence
-        # as we will remove last transition from the sequence and if we only have
-        # one transition, it leads to the required_error message instead
-        if not len(cfg.getTransitionsForPresentingAnItem()) > 1:
-            pm_logger.info('Could not make every checks in test_pm_validateTransitionsForPresentingAnItem '
-                           'because only one TransitionsForPresentingAnItem')
-            return
-        last_transition_error_msg = _('last_transition_must_result_in_presented_state')
-        sequence_with_last_removed = list(cfg.getTransitionsForPresentingAnItem())[:-1]
-        self.assertEqual(cfg.validate_transitionsForPresentingAnItem(sequence_with_last_removed),
-                         last_transition_error_msg)
-
     def test_pm_Validate_insertingMethodsOnAddItem(self):
         '''Test the MeetingConfig.insertingMethodsOnAddItem validation.
            We will test that :

--- a/src/Products/PloneMeeting/tests/testWorkflows.py
+++ b/src/Products/PloneMeeting/tests/testWorkflows.py
@@ -624,22 +624,21 @@ class testWorkflows(PloneMeetingTestCase):
         self.assertEqual(len(meeting.get_items()), 3)
         self.assertEqual(meeting.get_items(ordered=True)[-1].getPrivacy(), 'secret')
 
-    def test_pm_RecurringItemsWithWrongTransitionsForPresentingAnItem(self):
-        '''Tests the recurring items system when using a wrong
-           MeetingConfig.transitionsForPresentingAnItem.'''
+    def test_pm_RecurringItemsWithUntriggerableTransitions(self):
+        '''Tests the recurring items system when some transitions could not be triggered.'''
         cfg = self.meetingConfig
         self._setupRecurringItems()
         self.changeUser('pmManager')
         # now test with hardcoded transitions
         meeting = self.create('Meeting')
         # this meeting should contains the 3 usual recurring items
-        self.failIf(len(meeting.get_items()) != 3)
-        # if transitions for presenting an item are not correct
+        self.assertEqual(len(meeting.get_items()), 3)
+        # if transitions for presenting an item can not be triggered
         # the item will no be inserted in the meeting
         # enable categories so the recurring items are not presentable
         cfg.setUseGroupsAsCategories(False)
         meeting2 = self.create('Meeting')
-        self.failIf(len(meeting2.get_items()) != 0)
+        self.assertEqual(len(meeting2.get_items()), 0)
 
     def test_pm_RecurringItemsWithEmptySuffixInItemValidationLevels(self):
         '''Tests the recurring items system when an intermediate proposingGroup suffix


### PR DESCRIPTION
As information is in `MeetingConfig.itemWFValidationLevels`, method `MeetingConfig.getTransitionsForPresentingAnItem` is kept and does the job.

See #PM-3939