### PR TITLE
Added adaptable method `MeetingConfig._custom_createOrUpdateGroups` to ease a profile adding a custom `MeetingConfig` related group.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,11 @@ Changelog
 - Make sure dashboard cache is invlaidated (etags) when a meeting date changed,
   this is necessary so meeting date faceted filters are correct.
   [gbastien]
+- Added adaptable method `MeetingConfig._custom_createOrUpdateGroups` to ease
+  a profile adding a custom `MeetingConfig` related group.
+  `MeetingConfig._createOrUpdateAllPloneGroups` parameter `only_group_ids=False`
+  was renamed to `dry_run_return_group_ids=False`.
+  [gbastien]
 
 4.2rc30 (2022-07-01)
 --------------------

--- a/src/Products/PloneMeeting/interfaces.py
+++ b/src/Products/PloneMeeting/interfaces.py
@@ -614,6 +614,8 @@ class IMeetingConfigDocumentation:
            OrderedDict([('reviewers', ['prevalidated']), ('prereviewers', ['proposed'])]).
            This must only be provided if the MeetingConfig.reviewersFor
            automatic computation is not correct."""
+    def _custom_createOrUpdateGroups(self, force_update_access=False, dry_run_return_group_ids=False):
+        """Method that will add custom MeetingConfig related Plone groups."""
 
 
 class IMeetingConfigCustom(IMeetingConfig):


### PR DESCRIPTION
`MeetingConfig._createOrUpdateAllPloneGroups` parameter `only_group_ids=False` was renamed to `dry_run_return_group_ids=False`.

See #PM-3530