### PR TITLE
Added adaptable method `MeetingItem._annex_decision_addable_states_after_validation`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ Changelog
 - Added possibility to make a committee selectable only on an item and
   not on a meeting.
   [gbastien]
+- Added adaptable method `MeetingItem._annex_decision_addable_states_after_validation`
+  that will manage item states in which annex decision may be added after the
+  validation process so since the `validated` state until the end of the item WF.
+  [gbastien]
 
 4.2rc30 (2022-07-01)
 --------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -2970,6 +2970,10 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         for extra_marker in extra_markers:
             self.REQUEST.set(extra_marker, True)
 
+    def _annex_decision_addable_states_after_validation(self, cfg):
+        '''See doc in interfaces.py.'''
+        return cfg.getItemDecidedStates()
+
     security.declareProtected(ModifyPortalContent, 'setCategory')
 
     def setCategory(self, value, **kwargs):
@@ -6704,7 +6708,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         if not org_uid:
             return
         apply_meetingmanagers_access, suffix_roles = compute_item_roles_to_assign_to_suffixes(
-            cfg, item_state, org_uid)
+            cfg, self, item_state, org_uid)
 
         # apply local roles to computed suffixes
         self._assign_roles_to_group_suffixes(org_uid, suffix_roles)

--- a/src/Products/PloneMeeting/adapters.py
+++ b/src/Products/PloneMeeting/adapters.py
@@ -1242,7 +1242,8 @@ class BaseItemsToCorrectAdapter(CompoundCriterionBaseAdapter):
                 # roles that may edit
                 edit_roles = itemWF.states[review_state].permission_roles[ModifyPortalContent]
                 # suffixes information for review_state
-                roles_of_suffixes = compute_item_roles_to_assign_to_suffixes(self.cfg, review_state)[1]
+                roles_of_suffixes = compute_item_roles_to_assign_to_suffixes(
+                    self.cfg, None, review_state)[1]
                 # keep suffixes having relevant roles
                 suffixes = []
                 for suffix, roles in roles_of_suffixes.items():

--- a/src/Products/PloneMeeting/interfaces.py
+++ b/src/Products/PloneMeeting/interfaces.py
@@ -364,6 +364,10 @@ class IMeetingItemDocumentation:
     def _bypass_meeting_closed_check_for(self, fieldName):
         """Adaptable method that let bypass the
            mayQuickEdit.bypassMeetingClosedCheck for given p_fieldName."""
+    def _annex_decision_addable_states_after_validation(self, cfg):
+        """Return states in which annex decision are addable in the WF states after
+           the validation process (so when item is validated and after).
+           By default this will be when item is decided."""
 
 
 class IMeetingItemWorkflowConditions(Interface):

--- a/src/Products/PloneMeeting/utils.py
+++ b/src/Products/PloneMeeting/utils.py
@@ -2012,13 +2012,14 @@ def get_item_validation_wf_suffixes(cfg, org_uid=None, only_enabled=True):
     return suffixes
 
 
-def compute_item_roles_to_assign_to_suffixes_cachekey(method, cfg, item_state, org_uid=None):
+def compute_item_roles_to_assign_to_suffixes_cachekey(method, cfg, item, item_state, org_uid=None):
     '''cachekey method for compute_item_roles_to_assign_to_suffixes.'''
+    # we do not use item in the key, cfg and item_state is sufficient
     return cfg.getId(), cfg.modified(), item_state, org_uid
 
 
 @ram.cache(compute_item_roles_to_assign_to_suffixes_cachekey)
-def compute_item_roles_to_assign_to_suffixes(cfg, item_state, org_uid=None):
+def compute_item_roles_to_assign_to_suffixes(cfg, item, item_state, org_uid=None):
     """ """
     apply_meetingmanagers_access = True
     suffix_roles = {}
@@ -2079,10 +2080,11 @@ def compute_item_roles_to_assign_to_suffixes(cfg, item_state, org_uid=None):
         # we also give the Contributor except to 'observers'
         # so every editors roles get the "PloneMeeting: Add decision annex"
         # permission that let add decision annex
-        item_is_decided = item_state in cfg.getItemDecidedStates()
+        may_add_decision_annex = item_state in \
+            item.adapted()._annex_decision_addable_states_after_validation(cfg)
         for suffix in get_item_validation_wf_suffixes(cfg, org_uid):
             given_roles = ['Reader']
-            if item_is_decided and suffix != 'observers':
+            if may_add_decision_annex and suffix != 'observers':
                 given_roles.append('Contributor')
             suffix_roles[suffix] = given_roles
 


### PR DESCRIPTION
That will manage item states in which annex decision may be added after the validation process so since the `validated` state until the end of the item WF.

See #PM-3944
