### PR TITLE
Make sure a `MeetingCategory` can not be renamed if it is used.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,8 @@ Changelog
   that will check that there are no more items `Returned to proposing group` when
   publishing decisions.
   [gbastien]
+- Make sure a `MeetingCategory` can not be renamed if it is used.
+  [gbastien]
 
 4.2rc34 (2022-09-29)
 --------------------

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -20,6 +20,7 @@ from imio.helpers.content import richtextval
 from imio.helpers.security import fplog
 from imio.helpers.xhtml import storeImagesLocally
 from OFS.ObjectManager import BeforeDeleteException
+from OFS.interfaces import IObjectWillBeAddedEvent
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
 from plone import api
@@ -1448,8 +1449,8 @@ def onFacetedGlobalSettingsChanged(folder, event):
     _notifyContainerModified(folder)
 
 
-def onCategoryWillBeRemoved(category, event):
-    '''Checks if the current p_category can be deleted:
+def onCategoryWillBeMoved(category, event):
+    '''Checks if the current p_category can be moved (renamed) or deleted:
       - it can not be linked to an existing meetingItem (normal item,
         recurring item or item template);
       - it can not be used in field 'category_mapping_when_cloning_to_other_mc'
@@ -1457,6 +1458,10 @@ def onCategoryWillBeRemoved(category, event):
     # If we are trying to remove the whole Plone Site, bypass this hook.
     # bypass also if we are in the creation process
     if event.object.meta_type == 'Plone Site':
+        return
+
+    # also called when new category created
+    if IObjectWillBeAddedEvent.providedBy(event):
         return
 
     tool = api.portal.get_tool('portal_plonemeeting')

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -19,8 +19,8 @@ from imio.helpers.content import get_modified_attrs
 from imio.helpers.content import richtextval
 from imio.helpers.security import fplog
 from imio.helpers.xhtml import storeImagesLocally
-from OFS.ObjectManager import BeforeDeleteException
 from OFS.interfaces import IObjectWillBeAddedEvent
+from OFS.ObjectManager import BeforeDeleteException
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
 from plone import api

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -1457,11 +1457,8 @@ def onCategoryWillBeMoved(category, event):
         of another meetingcategory.'''
     # If we are trying to remove the whole Plone Site, bypass this hook.
     # bypass also if we are in the creation process
-    if event.object.meta_type == 'Plone Site':
-        return
-
-    # also called when new category created
-    if IObjectWillBeAddedEvent.providedBy(event):
+    if event.object.meta_type == 'Plone Site' or \
+       IObjectWillBeAddedEvent.providedBy(event):
         return
 
     tool = api.portal.get_tool('portal_plonemeeting')

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -1449,7 +1449,7 @@ def onFacetedGlobalSettingsChanged(folder, event):
     _notifyContainerModified(folder)
 
 
-def onCategoryWillBeMoved(category, event):
+def onCategoryWillBeMovedOrRemoved(category, event):
     '''Checks if the current p_category can be moved (renamed) or deleted:
       - it can not be linked to an existing meetingItem (normal item,
         recurring item or item template);

--- a/src/Products/PloneMeeting/events.zcml
+++ b/src/Products/PloneMeeting/events.zcml
@@ -105,7 +105,7 @@
 
   <subscriber for=".content.category.IMeetingCategory
                    OFS.interfaces.IObjectWillBeMovedEvent"
-              handler=".events.onCategoryWillBeMoved" />
+              handler=".events.onCategoryWillBeMovedOrRemoved" />
 
   <subscriber for=".content.organization.IPMOrganization
                    OFS.interfaces.IObjectWillBeRemovedEvent"

--- a/src/Products/PloneMeeting/events.zcml
+++ b/src/Products/PloneMeeting/events.zcml
@@ -16,7 +16,7 @@
               handler=".events.onItemInitialized" />
 
   <subscriber for=".interfaces.IMeetingItem
-                   zope.lifecycleevent.interfaces.IObjectAddedEvent"
+                   zope.lifecycleevent.IObjectAddedEvent"
               handler=".events.onItemAdded" />
 
   <subscriber for=".interfaces.IMeetingItem
@@ -36,11 +36,11 @@
               handler=".events.onItemRemoved" />
 
   <subscriber for=".interfaces.IMeetingItem
-                   zope.lifecycleevent.ObjectCopiedEvent"
+                   zope.lifecycleevent.IObjectCopiedEvent"
               handler=".events.onItemCopied" />
 
   <subscriber for=".interfaces.IMeetingItem
-                   zope.lifecycleevent.ObjectMovedEvent"
+                   zope.lifecycleevent.IObjectMovedEvent"
               handler=".events.onItemMoved" />
 
   <subscriber for=".interfaces.IMeetingItem
@@ -72,11 +72,11 @@
               handler=".events.onItemEditCancelled" />
 
   <subscriber for=".content.meeting.IMeeting
-                   zope.lifecycleevent.interfaces.IObjectAddedEvent"
+                   zope.lifecycleevent.IObjectAddedEvent"
               handler=".events.onMeetingAdded" />
 
   <subscriber for=".content.meeting.IMeeting
-                   zope.lifecycleevent.interfaces.IObjectCreatedEvent"
+                   zope.lifecycleevent.IObjectCreatedEvent"
               handler=".events.onMeetingCreated" />
 
   <subscriber for=".content.meeting.IMeeting
@@ -88,7 +88,7 @@
               handler=".events.onMeetingTransition" />
 
   <subscriber for=".content.meeting.IMeeting
-                   zope.lifecycleevent.ObjectMovedEvent"
+                   zope.lifecycleevent.IObjectMovedEvent"
               handler=".events.onMeetingMoved" />
 
   <subscriber for=".content.meeting.IMeeting
@@ -104,8 +104,8 @@
               handler=".events.onConfigWillBeRemoved" />
 
   <subscriber for=".content.category.IMeetingCategory
-                   OFS.interfaces.IObjectWillBeRemovedEvent"
-              handler=".events.onCategoryWillBeRemoved" />
+                   OFS.interfaces.IObjectWillBeMovedEvent"
+              handler=".events.onCategoryWillBeMoved" />
 
   <subscriber for=".content.organization.IPMOrganization
                    OFS.interfaces.IObjectWillBeRemovedEvent"
@@ -116,7 +116,7 @@
               handler=".events.onOrgRemoved" />
 
   <subscriber for=".interfaces.IConfigElement
-                   zope.lifecycleevent.interfaces.IObjectAddedEvent"
+                   zope.lifecycleevent.IObjectAddedEvent"
               handler=".events.onConfigOrPloneElementAdded" />
 
   <subscriber for=".interfaces.IConfigElement
@@ -132,7 +132,7 @@
               handler=".events.onConfigOrPloneElementRemoved" />
 
   <subscriber for=".interfaces.IPloneElement
-                   zope.lifecycleevent.interfaces.IObjectAddedEvent"
+                   zope.lifecycleevent.IObjectAddedEvent"
               handler=".events.onConfigOrPloneElementAdded" />
 
   <subscriber for=".interfaces.IPloneElement
@@ -161,7 +161,7 @@
               handler=".events.onAdviceEditFinished" />
 
   <subscriber for=".content.advice.IMeetingAdvice
-                   zope.lifecycleevent.interfaces.IObjectAddedEvent"
+                   zope.lifecycleevent.IObjectAddedEvent"
               handler=".events.onAdviceAdded" />
 
   <subscriber for=".content.advice.IMeetingAdvice
@@ -174,7 +174,7 @@
 
   <!-- imio.annex events -->
   <subscriber for="imio.annex.content.annex.IAnnex
-                   zope.lifecycleevent.interfaces.IObjectAddedEvent"
+                   zope.lifecycleevent.IObjectAddedEvent"
               handler=".events.onAnnexAdded" />
 
   <subscriber for="imio.annex.content.annex.IAnnex
@@ -214,7 +214,7 @@
 
   <!-- DashboardCollection events -->
   <subscriber for="collective.eeafaceted.collectionwidget.interfaces.IDashboardCollection
-                   zope.lifecycleevent.interfaces.IObjectAddedEvent"
+                   zope.lifecycleevent.IObjectAddedEvent"
               handler=".events.onDashboardCollectionAdded" />
 
   <subscriber for="plone.registry.interfaces.IRecordModifiedEvent"

--- a/src/Products/PloneMeeting/tests/testMeetingCategory.py
+++ b/src/Products/PloneMeeting/tests/testMeetingCategory.py
@@ -122,6 +122,26 @@ class testMeetingCategory(PloneMeetingTestCase):
         '''While removing a classifier, it should raise if it is linked...'''
         self._checkCategoryRemoval(classifier=True)
 
+    def test_pm_CanNotRenameUsedCategory(self):
+        """As well as deleted, a used category can not be renamed neither as we
+           us it's identifier as key."""
+        #self._enableField('category')
+        self.meetingConfig.setUseGroupsAsCategories(False)
+        self.changeUser('pmCreator1')
+        # use a category that is not used in MeetingConfig (default itemtemplate)
+        item = self.create('MeetingItem', category="events")
+        self.assertEqual(item.getCategory(), "events")
+        self.changeUser('siteadmin')
+        category = item.getCategory(True)
+        self.assertRaises(BeforeDeleteException,
+                          category.aq_parent.manage_renameObject,
+                          category.getId(),
+                          'my_new_id')
+        item.setCategory('development')
+        item._update_after_edit()
+        category.aq_parent.manage_renameObject(category.getId(), 'my_new_id')
+        self.assertEqual(category.getId(), 'my_new_id')
+
     def test_pm_ListCategoriesOfOtherMCs(self):
         '''Test the vocabulary of the 'category_mapping_when_cloning_to_other_mc' field.'''
         cfg = self.meetingConfig


### PR DESCRIPTION
See #PM-4028