### PR TITLE
Fixed `ItemDocumentGenerationHelperView.print_votes`, make sure voters are ordered when `include_voters=True`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -155,6 +155,12 @@ Changelog
   `BaseMeetingView.show_field` ignores not used boolean fields that are `False`
   and special management for `IMeeting.place` field.
   [gbastien]
+- Fixed `ItemDocumentGenerationHelperView.print_votes`, make sure voters
+  are ordered when `include_voters=True`. Fixed `Meeting._get_contacts` to take
+  into account parameter `uids` order when given.
+  Fixed `MeetingItem.get_item_votes`, use an `OrderedDict` instead a `Dict`
+  to store voters to preserve order.
+  [gbastien]
 
 4.2rc34 (2022-09-29)
 --------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -4534,11 +4534,11 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
                 # this could not be the case when encoding votes
                 # for a voter then setting him absent
                 # discard also ignored_vote_values
-                vote['voters'] = {vote_voter_uid: vote_voter_value
-                                  for vote_voter_uid, vote_voter_value in vote['voters'].items()
-                                  if vote_voter_uid in voter_uids and
-                                  (not ignored_vote_values or
-                                   vote_voter_value not in ignored_vote_values)}
+                vote['voters'] = OrderedDict(
+                    [(vote_voter_uid, vote['voters'][vote_voter_uid])
+                     for vote_voter_uid in voter_uids
+                     if (not ignored_vote_values or
+                         vote['voters'][vote_voter_uid] not in ignored_vote_values)])
             i = i + 1
 
         # when asking a vote_number, only return this one as a dict, not as a list

--- a/src/Products/PloneMeeting/content/meeting.py
+++ b/src/Products/PloneMeeting/content/meeting.py
@@ -1252,18 +1252,19 @@ class Meeting(Container):
 
     def _get_contacts(self, contact_type=None, uids=None, the_objects=False):
         """Return contacts.  Parameters p_contact_type and p_uids are mutually exclusive."""
-        contact_uids = []
+        res = []
         ordered_contacts = getattr(self, 'ordered_contacts', OrderedDict())
         if contact_type:
-            for uid, infos in ordered_contacts.items():
-                if infos[contact_type] and (not uids or uid in uids):
-                    contact_uids.append(uid)
+            # if we have uids, we keep it's order
+            uids = uids or ordered_contacts.keys()
+            for uid in uids:
+                if ordered_contacts[uid][contact_type]:
+                    res.append(uid)
         else:
-            contact_uids = uids
+            res = uids
 
-        res = contact_uids
         if res and the_objects:
-            res = uuidsToObjects(contact_uids, ordered=True, unrestricted=True)
+            res = uuidsToObjects(res, ordered=True, unrestricted=True)
         return tuple(res)
 
     security.declarePublic('get_attendees')

--- a/src/Products/PloneMeeting/tests/testVotes.py
+++ b/src/Products/PloneMeeting/tests/testVotes.py
@@ -175,10 +175,41 @@ class testVotes(PloneMeetingTestCase):
         self.assertEqual(helper_secret.print_votes(include_total_voters=True),
                          u'<p>Il y a 4 votants.</p><p>Au scrutin secret,</p>'
                          u'<p>Par une voix pour, une voix contre et 2 abstentions,</p>')
-        # public vote all yes and secret_intro
+        # secret vote all yes and secret_intro
         self.assertEqual(helper_yes_secret.print_votes(secret_intro=u"<p>À bulletin secret,</p>"),
                          u"<p>\xc0 bulletin secret,</p>"
                          u"<p>\xc0 l'unanimit\xe9,</p>")
+
+        # include_voters=True
+        # public vote
+        self.assertEqual(
+            helper_public.print_votes(include_voters=True),
+            u'<p>Par 2 voix pour<p>Monsieur Person1FirstName Person1LastName, '
+            u'Assembly member 1, Monsieur Person2FirstName Person2LastName, '
+            u'Assembly member 2</p>, une voix contre<p>Madame Person3FirstName '
+            u'Person3LastName, Assembly member 3</p> et une abstention<p>Madame '
+            u'Person4FirstName Person4LastName, Assembly member 4 &amp; 5</p>,</p>')
+        # public vote all yes
+        self.assertEqual(
+            helper_yes_public.print_votes(include_voters=True),
+            u"<p>\xc0 l'unanimit\xe9,</p>")
+        self.assertEqual(
+            helper_yes_public.print_votes(include_voters=True, all_yes_render=None),
+            u'<p>Par 4 voix pour<p>'
+            u'Monsieur Person1FirstName Person1LastName, Assembly member 1, '
+            u'Monsieur Person2FirstName Person2LastName, Assembly member 2, '
+            u'Madame Person3FirstName Person3LastName, Assembly member 3, '
+            u'Madame Person4FirstName Person4LastName, Assembly member 4 &amp; 5</p>,</p>')
+        # change an assembly member order, it is taken into account
+        change_view = yes_public_item.restrictedTraverse('@@item-change-attendee-order')
+        change_view(attendee_uid=public_item.get_all_attendees()[0], position=3)
+        self.assertEqual(
+            helper_yes_public.print_votes(include_voters=True, all_yes_render=None),
+            u'<p>Par 4 voix pour'
+            u'<p>Monsieur Person2FirstName Person2LastName, Assembly member 2, '
+            u'Madame Person3FirstName Person3LastName, Assembly member 3, '
+            u'Monsieur Person1FirstName Person1LastName, Assembly member 1, '
+            u'Madame Person4FirstName Person4LastName, Assembly member 4 &amp; 5</p>,</p>')
 
         # no votes
         meeting.item_votes[public_item.UID()] = []


### PR DESCRIPTION
Fixed `Meeting._get_contacts` to take into account parameter `uids` order when given. Fixed `MeetingItem.get_item_votes`, use an `OrderedDict` instead a `Dict` to store voters to preserve order.

See #SUP-25712