### PR TITLE
When removing an item from a meeting, make sure item `UID` is removed from `Meeting.item_attendees_positions` and `Meeting.item_attendees_order`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@ Changelog
   `ContentCategory.other_mc_correspondences` is defined
   (but `scan_id` is set to `None`).
   [gbastien]
+- When removing an item from a meeting, make sure item `UID` is removed from
+  `Meeting.item_attendees_positions` and `Meeting.item_attendees_order`.
+  This rely now on `config.MEETING_ATTENDEES_ATTRS` that makes sure that every
+  meeting attendees custom attributes are cleaned when item is removed.
+  [gbastien]
 
 4.2.4 (2023-07-12)
 ------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -7739,7 +7739,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         # If we are here, everything has already been checked before.
         # Just check that the item is myself, a Plone Site or removing a MeetingConfig.
         # We can remove an item directly, not "through" his container.
-        if item.meta_type not in ['Plone Site', 'MeetingConfig', 'MeetingItem', ]:
+        if item.meta_type not in ('Plone Site', 'MeetingConfig', 'MeetingItem'):
             user_id = get_current_user_id(item.REQUEST)
             logger.warn(BEFOREDELETE_ERROR % (user_id, self.id))
             raise BeforeDeleteException(

--- a/src/Products/PloneMeeting/config.py
+++ b/src/Products/PloneMeeting/config.py
@@ -380,6 +380,23 @@ REINDEX_NEEDED_MARKER = "_catalog_reindex_needed"
 # prefix used in pm_technical_index to store item initiators
 ITEM_INITIATOR_INDEX_PATTERN = "item_initiator_{0}"
 
+# various place where attendees infos are stored on meeting
+MEETING_ATTENDEES_ATTRS = (
+    # place to store item absents
+    'item_absents',
+    # place to store item excused
+    'item_excused',
+    # place to store item non attendees
+    'item_non_attendees',
+    # place to store item signatories
+    'item_signatories',
+    # place to store item attendees changed position
+    'item_attendees_positions',
+    # place to store item attendees changed order
+    'item_attendees_order',
+    # place to store item votes
+    'item_votes')
+
 
 def registerClasses():
     '''ArchGenXML generated code does not register Archetype classes at the

--- a/src/Products/PloneMeeting/content/meeting.py
+++ b/src/Products/PloneMeeting/content/meeting.py
@@ -42,6 +42,7 @@ from Products.PloneMeeting.browser.itemchangeorder import _is_integer
 from Products.PloneMeeting.browser.itemchangeorder import _to_integer
 from Products.PloneMeeting.browser.itemchangeorder import _use_same_integer
 from Products.PloneMeeting.browser.itemvotes import clean_voters_linked_to
+from Products.PloneMeeting.config import MEETING_ATTENDEES_ATTRS
 from Products.PloneMeeting.config import NOT_ENCODED_VOTE_VALUE
 from Products.PloneMeeting.config import NOT_VOTABLE_LINKED_TO_VALUE
 from Products.PloneMeeting.config import PMMessageFactory as _
@@ -1921,18 +1922,11 @@ class Meeting(Container):
             # so we pass
             pass
 
-        # remove item UID from self.item_absents/self.item_excused and self.item_signatories
+        # remove item UID from meeting attendees attributes
         item_uid = item.UID()
-        if item_uid in self.item_absents:
-            del self.item_absents[item_uid]
-        if item_uid in self.item_excused:
-            del self.item_excused[item_uid]
-        if item_uid in self.item_non_attendees:
-            del self.item_non_attendees[item_uid]
-        if item_uid in self.item_signatories:
-            del self.item_signatories[item_uid]
-        if item_uid in self.item_votes:
-            del self.item_votes[item_uid]
+        for attendee_attr in MEETING_ATTENDEES_ATTRS:
+            if item_uid in getattr(self, attendee_attr):
+                del getattr(self, attendee_attr)[item_uid]
 
         # remove item UID from _insert_order_cache
         self._invalidate_insert_order_cache_for(item)

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -44,6 +44,7 @@ from Products.PloneMeeting.config import ITEM_NO_PREFERRED_MEETING_VALUE
 from Products.PloneMeeting.config import ITEM_SCAN_ID_NAME
 from Products.PloneMeeting.config import ITEMTEMPLATESMANAGERS_GROUP_SUFFIX
 from Products.PloneMeeting.config import MEETING_CONFIG
+from Products.PloneMeeting.config import MEETING_ATTENDEES_ATTRS
 from Products.PloneMeeting.config import MEETING_REMOVE_MOG_WFA
 from Products.PloneMeeting.config import MEETINGMANAGERS_GROUP_SUFFIX
 from Products.PloneMeeting.config import PMMessageFactory as _
@@ -1206,20 +1207,8 @@ def onMeetingCreated(meeting, event):
        - added."""
     userId = get_current_user_id(meeting.REQUEST)
     meeting.manage_addLocalRoles(userId, ('Owner',))
-    # place to store item absents
-    meeting.item_absents = PersistentMapping()
-    # place to store item excused
-    meeting.item_excused = PersistentMapping()
-    # place to store item non attendees
-    meeting.item_non_attendees = PersistentMapping()
-    # place to store item signatories
-    meeting.item_signatories = PersistentMapping()
-    # place to store item attendees changed position
-    meeting.item_attendees_positions = PersistentMapping()
-    # place to store item attendees changed order
-    meeting.item_attendees_order = PersistentMapping()
-    # place to store item votes
-    meeting.item_votes = PersistentMapping()
+    for attendee_attr in MEETING_ATTENDEES_ATTRS:
+        setattr(meeting, attendee_attr, PersistentMapping())
     # place to store attendees when using contacts
     meeting.ordered_contacts = OrderedDict()
     meeting._number_of_items = 0

--- a/src/Products/PloneMeeting/tests/testContacts.py
+++ b/src/Products/PloneMeeting/tests/testContacts.py
@@ -2626,6 +2626,10 @@ class testContacts(PloneMeetingTestCase):
         # still on item1, no more on item2
         self.assertEqual(meeting.get_attendee_position_for(item1_uid, hp1_uid), u"dg")
         self.assertEqual(meeting.get_attendee_position_for(item2_uid, hp1_uid), u"default")
+        # when item removed from meeting, info removed from item_attendees_positions
+        self.assertTrue(item1_uid in meeting.item_attendees_positions)
+        self.backToState(item1, 'validated')
+        self.assertFalse(item1_uid in meeting.item_attendees_positions)
 
     def test_pm_HeldPositionDefaultPosition(self):
         """When adding a held_position, the default position is set to the own organization."""
@@ -2710,6 +2714,12 @@ class testContacts(PloneMeetingTestCase):
         reinit_view = item1.restrictedTraverse('@@item-reinit-attendees-order')
         reinit_view()
         self.assertEqual(invariants.validate(data), ())
+
+        # when item removed from meeting, info removed from item_attendees_positions
+        change_view(attendee_uid=item1.get_all_attendees()[1], position=3)
+        self.assertTrue(item1_uid in meeting.item_attendees_order)
+        self.backToState(item1, 'validated')
+        self.assertFalse(item1_uid in meeting.item_attendees_order)
 
 
 def test_suite():


### PR DESCRIPTION
This rely now on `config.MEETING_ATTENDEES_ATTRS` that makes sure that every meeting attendees custom attributes are cleaned when item is removed. See #PM-4116