### PR TITLE
Fixed `ItemOptionalAdvicesVocabulary` to manage correctly missing terms when it involves userids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 ------------------
 
 - Fixed `ItemOptionalAdvicesVocabulary` to manage correctly missing terms when
-  it involves userids.
+  it involves userids. Added caching as it is used when editing an item.
   [gbastien]
 
 4.2.6 (2023-09-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Changelog
 4.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fixed `ItemOptionalAdvicesVocabulary` to manage correctly missing terms when
+  it involves userids.
+  [gbastien]
 
 4.2.6 (2023-09-21)
 ------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -5883,6 +5883,10 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         def _get_adviser_name(adviser):
             """Manage adviser name, will append selected __userid__ if any."""
             name = html.escape(adviser['name'])
+            if adviser['delay_label']:
+                name += u" - {0} ({1})".format(
+                    safe_unicode(html.escape(adviser['delay_label'])),
+                    safe_unicode(adviser['delay']))
             if adviser['userids']:
                 name += u" ({0})".format(
                     self._displayAdviserUsers(adviser['userids'], portal_url, tool))

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -6725,13 +6725,11 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
                                      domain="PloneMeeting",
                                      context=self.REQUEST)
             else:
-                help_msg = translate('This optional advice was asked by the item creators '
-                                     '(shown by his title being between brackets)',
+                help_msg = translate('This optional advice was asked by the item creators',
                                      domain="PloneMeeting",
                                      context=self.REQUEST)
         else:
-            help_msg = translate('This automatic advice has been asked by the application '
-                                 '(shown by his title not being between brackets)',
+            help_msg = translate('This automatic advice has been asked by the application',
                                  domain="PloneMeeting",
                                  context=self.REQUEST)
             # an additional help message can be provided for automatically asked advices

--- a/src/Products/PloneMeeting/browser/advices.py
+++ b/src/Products/PloneMeeting/browser/advices.py
@@ -2,7 +2,6 @@
 
 from AccessControl import Unauthorized
 from collective.contact.plonegroup.utils import get_plone_group_id
-from DateTime import DateTime
 from imio.actionspanel.interfaces import IContentDeletable
 from imio.helpers.cache import get_plone_groups_for_user
 from imio.helpers.workflow import get_state_infos

--- a/src/Products/PloneMeeting/browser/templates/advices-icons-infos.pt
+++ b/src/Products/PloneMeeting/browser/templates/advices-icons-infos.pt
@@ -78,12 +78,11 @@
                       </acronym>
                   </tal:inherited_advice>
                   <div class="advice_popup_label">
-                    <span tal:condition="advice/optional">(</span>
                     <span class="advice-name" tal:content="advice/name"></span>
                     <tal:showDelayLabel condition="python: advice['delay'] and advice['delay_label']">
                     - <span class="advice-label" tal:content="advice/delay_label"></span>
                     </tal:showDelayLabel>
-                    <span tal:condition="advice/optional">)</span>
+                    <span tal:condition="python: not advice['optional']">[auto]</span>
                   </div>
                   <div class="advice_popup_actions">
                      &nbsp;&nbsp;

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -34,6 +34,7 @@ from plone import api
 from plone.app.textfield import RichText
 from plone.registry.interfaces import IRecordModifiedEvent
 from plone.restapi.deserializer import json_body
+from Products.Archetypes.event import ObjectEditedEvent
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
 from Products.PloneMeeting.config import BARCODE_INSERTED_ATTR_ID
@@ -460,19 +461,25 @@ def onRegistryModified(event):
             unselected_org_uids = list(old_set.difference(new_set))
             tool = api.portal.get_tool('portal_plonemeeting')
             for unselected_org_uid in unselected_org_uids:
-                # Remove the org from every meetingConfigs.selectableCopyGroups
-                for mc in tool.objectValues('MeetingConfig'):
-                    selectableCopyGroups = list(mc.getSelectableCopyGroups())
+                # Remove the org from every meetingConfigs.selectableCopyGroups and
+                # from every meetingConfigs.selectableAdvisers
+                for cfg in tool.objectValues('MeetingConfig'):
+                    update_cfg = False
+                    selectableCopyGroups = list(cfg.getSelectableCopyGroups())
                     for plone_group_id in get_plone_groups(unselected_org_uid, ids_only=True):
                         if plone_group_id in selectableCopyGroups:
+                            update_cfg = True
                             selectableCopyGroups.remove(plone_group_id)
-                    mc.setSelectableCopyGroups(selectableCopyGroups)
-                # Remove the org from every meetingConfigs.selectableAdvisers
-                for mc in tool.objectValues('MeetingConfig'):
-                    selectableAdvisers = list(mc.getSelectableAdvisers())
-                    if unselected_org_uid in mc.getSelectableAdvisers():
+                            cfg.setSelectableCopyGroups(selectableCopyGroups)
+                    selectableAdvisers = list(cfg.getSelectableAdvisers())
+                    if unselected_org_uid in cfg.getSelectableAdvisers():
+                        update_cfg = True
                         selectableAdvisers.remove(unselected_org_uid)
-                    mc.setSelectableAdvisers(selectableAdvisers)
+                        cfg.setSelectableAdvisers(selectableAdvisers)
+                    if update_cfg:
+                        # especially invalidate cache
+                        notify(ObjectEditedEvent(cfg))
+
                 # add a portal_message explaining what has been done to the user
                 plone_utils = api.portal.get_tool('plone_utils')
                 plone_utils.addPortalMessage(

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -308,8 +308,6 @@ def _invalidateOrgRelatedCachedVocabularies():
         "Products.PloneMeeting.vocabularies.everyorganizationsacronymsvocabulary", get_again=True)
     invalidate_cachekey_volatile_for(
         "Products.PloneMeeting.vocabularies.groupsinchargevocabulary", get_again=True)
-    invalidate_cachekey_volatile_for(
-        "Products.PloneMeeting.vocabularies.askedadvicesvocabulary", get_again=True)
     # also invalidated here, called from organization._invalidateCachedMethods
     invalidate_cachekey_volatile_for('_users_groups_value', get_again=True)
 

--- a/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeeting.css.dtml
+++ b/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeeting.css.dtml
@@ -560,6 +560,11 @@ div#content.advice_infos_tooltipster legend acronym {
    margin-right: 0.25em;
 }
 
+/* align [+][-] with following text and icons */
+div#content.advice_infos_tooltipster div.collapsible {
+    vertical-align: bottom;
+}
+
 /* display pretty link "not viewable" correctly */
 div#content.meeting_item_absents_tooltipster div.pretty_link {
    display: inline-block;

--- a/src/Products/PloneMeeting/tests/testFaceted.py
+++ b/src/Products/PloneMeeting/tests/testFaceted.py
@@ -634,6 +634,7 @@ class testFaceted(PloneMeetingTestCase):
         new_org = self.create('organization', title='New organization', acronym='N.G.')
         new_org_uid = new_org.UID()
         cfg.setSelectableAdvisers(cfg.getSelectableAdvisers() + (new_org_uid, ))
+        notify(ObjectEditedEvent(cfg))
         # cache was cleaned
         self.assertEqual(len(vocab(pmFolder)), 7)
         # edit an organization

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -4032,6 +4032,7 @@ class testMeetingItem(PloneMeetingTestCase):
                            'is_linked_to_previous_row': '1',
                            'delay': '10'}]
         cfg.setCustomAdvisers(customAdvisers)
+        notify(ObjectEditedEvent(cfg))
         self.assertFalse('{0}__rowid__unique_id_123'.format(self.developers_uid) in vocab_factory(item))
         self.assertTrue('{0}__rowid__unique_id_456'.format(self.developers_uid) in vocab_factory(item))
         # but if selected, then it appears in the vocabulary, no matter the 'available_on' expression
@@ -4064,7 +4065,6 @@ class testMeetingItem(PloneMeetingTestCase):
              '{0}__userid__pmManager'.format(self.developers_uid),
              self.vendors_uid])
         # when selected on an item, available in the vocabulary
-        notify(ObjectEditedEvent(cfg))
         item.setOptionalAdvisers(('{0}__userid__pmCreator2'.format(self.vendors_uid), ))
         item._update_after_edit()
         self.assertEqual(
@@ -4149,6 +4149,7 @@ class testMeetingItem(PloneMeetingTestCase):
                            'for_item_created_from': '2012/01/01',
                            'delay': '10'}, ]
         cfg.setCustomAdvisers(customAdvisers)
+        notify(ObjectEditedEvent(cfg))
         # a special key is prepended that will be disabled in the UI
         # at the beginning of 'both' list (delay-aware and non delay-aware advisers)
         vocab_keys = [term.token for term in vocab_factory(item)._terms]
@@ -4162,6 +4163,7 @@ class testMeetingItem(PloneMeetingTestCase):
         # check that if a 'for_item_created_until' date is passed, it does not appear anymore
         customAdvisers[1]['for_item_created_until'] = '2013/01/01'
         cfg.setCustomAdvisers(customAdvisers)
+        notify(ObjectEditedEvent(cfg))
         vocab_keys = [term.token for term in vocab_factory(item)._terms]
         self.assertEqual(vocab_keys,
                          ['not_selectable_value_delay_aware_optional_advisers',
@@ -4175,6 +4177,7 @@ class testMeetingItem(PloneMeetingTestCase):
         customAdvisers[1]['for_item_created_until'] = ''
         customAdvisers[0]['available_on'] = 'python:False'
         cfg.setCustomAdvisers(customAdvisers)
+        notify(ObjectEditedEvent(cfg))
         vocab_keys = [term.token for term in vocab_factory(item)._terms]
         self.assertEqual(vocab_keys,
                          ['not_selectable_value_delay_aware_optional_advisers',
@@ -4186,6 +4189,7 @@ class testMeetingItem(PloneMeetingTestCase):
         # but the customAdviser is simply not taken into account
         customAdvisers[0]['available_on'] = 'python: here.someMissingMethod(some_parameter=False)'
         cfg.setCustomAdvisers(customAdvisers)
+        notify(ObjectEditedEvent(cfg))
         vocab_keys = [term.token for term in vocab_factory(item)._terms]
         self.assertEqual(vocab_keys,
                          ['not_selectable_value_delay_aware_optional_advisers',

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -4063,6 +4063,56 @@ class testMeetingItem(PloneMeetingTestCase):
              '{0}__userid__pmAdviser1'.format(self.developers_uid),
              '{0}__userid__pmManager'.format(self.developers_uid),
              self.vendors_uid])
+        # when selected on an item, available in the vocabulary
+        notify(ObjectEditedEvent(cfg))
+        item.setOptionalAdvisers(('{0}__userid__pmCreator2'.format(self.vendors_uid), ))
+        item._update_after_edit()
+        self.assertEqual(
+            [t.title for t in vocab_factory(item)],
+            [u'Please select among delay-aware advisers',
+             u'Developers - 10 day(s)',
+             u'M. PMAdviser One (H\xe9)',
+             u'M. PMManager',
+             u'Please select among non delay-aware advisers',
+             u'Developers',
+             u'M. PMAdviser One (H\xe9)',
+             u'M. PMManager',
+             u'Vendors',
+             # new value correctly sorted, the other users are not listed
+             u'M. PMCreator Two'])
+        # now select on item a user from an org that is no more in the vocabulary
+        item.setOptionalAdvisers(('{0}__userid__pmCreator1'.format(self.endUsers_uid), ))
+        self.assertEqual(
+            [t.title for t in vocab_factory(item)],
+            [u'Please select among delay-aware advisers',
+             u'Developers - 10 day(s)',
+             u'M. PMAdviser One (H\xe9)',
+             u'M. PMManager',
+             # new value with org and user on one line so it is not possible to select the org
+             u'End users (M. PMCreator One)',
+             u'Please select among non delay-aware advisers',
+             u'Developers',
+             u'M. PMAdviser One (H\xe9)',
+             u'M. PMManager',
+             u'Vendors'])
+        # add a delay aware value to an existing org but with a no longer existing user
+        item.setOptionalAdvisers((
+            '{0}__userid__pmCreator1'.format(self.endUsers_uid),
+            '{0}__rowid__unique_id_456__userid__pmAdviser2'.format(self.developers_uid)))
+        self.assertEqual(
+            [t.title for t in vocab_factory(item)],
+            [u'Please select among delay-aware advisers',
+             u'Developers - 10 day(s)',
+             u'M. PMAdviser One (H\xe9)',
+             u'M. PMManager',
+             # new value, just the user as the org exist, and just the user id as user does not exist
+             u'pmAdviser2',
+             u'End users (M. PMCreator One)',
+             u'Please select among non delay-aware advisers',
+             u'Developers',
+             u'M. PMAdviser One (H\xe9)',
+             u'M. PMManager',
+             u'Vendors'])
 
     def test_pm_OptionalAdvisersDelayAwareAdvisers(self):
         '''


### PR DESCRIPTION
See #PM-4123