### PR TITLE
Removed `config.BARCODE_INSERTED_ATTR_ID`, we do not use it anymore to check if a barcode was inserted, we rely on the `scan_id`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog
   [gbastien]
 - Added a new utils `set_internal_number` to be able to change the `internal_number`.
   [aduchene]
+- Removed `config.BARCODE_INSERTED_ATTR_ID`, we do not use it anymore to check
+  if a barcode was inserted, we rely on the `scan_id`.
+  [gbastien]
 
 4.2.7 (2023-10-19)
 ------------------

--- a/src/Products/PloneMeeting/browser/overrides.py
+++ b/src/Products/PloneMeeting/browser/overrides.py
@@ -48,7 +48,6 @@ from Products.CMFPlone.browser.ploneview import Plone
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.PloneMeeting.config import BARCODE_INSERTED_ATTR_ID
 from Products.PloneMeeting.config import HAS_RESTAPI
 from Products.PloneMeeting.config import ITEM_DEFAULT_TEMPLATE_ID
 from Products.PloneMeeting.config import ITEM_SCAN_ID_NAME
@@ -1274,10 +1273,6 @@ class PMDocumentGenerationView(DashboardDocumentGenerationView):
             confidential=confidential_default,
             used_pod_template_id=pod_template.getId(),
             scan_id=scan_id)
-        # if we have a scan_id it means that a barcode has been inserted
-        # in the generated document, we mark stored annex as barcoded
-        if scan_id:
-            setattr(annex, BARCODE_INSERTED_ATTR_ID, True)
 
     def _get_stored_annex_title(self, pod_template):
         """Generates the stored annex title using the ConfigurablePODTemplate.store_as_annex_title_expr.

--- a/src/Products/PloneMeeting/config.py
+++ b/src/Products/PloneMeeting/config.py
@@ -272,8 +272,6 @@ ADVICE_STATES_ENDED = ('advice_given', )
 
 # name of the variable added to the REQUEST when getting the scan_id
 ITEM_SCAN_ID_NAME = 'item_scan_id'
-# name of the aribale specifying that an annex has been barcoded
-BARCODE_INSERTED_ATTR_ID = '_barcode_inserted'
 
 # Keys used in annotations
 SENT_TO_OTHER_MC_ANNOTATION_BASE_KEY = 'PloneMeeting-sent_to_other_meetingconfig_'

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -37,7 +37,6 @@ from plone.restapi.deserializer import json_body
 from Products.Archetypes.event import ObjectEditedEvent
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
-from Products.PloneMeeting.config import BARCODE_INSERTED_ATTR_ID
 from Products.PloneMeeting.config import BUDGETIMPACTEDITORS_GROUP_SUFFIX
 from Products.PloneMeeting.config import ITEM_DEFAULT_TEMPLATE_ID
 from Products.PloneMeeting.config import ITEM_INITIATOR_INDEX_PATTERN
@@ -1032,13 +1031,13 @@ def onAnnexModified(annex, event):
 
 
 def onAnnexFileChanged(annex, event):
-    '''Remove BARCODE_ATTR_ID of annex if any except:
+    '''Remove scan_id of annex if any, except:
        - if ITEM_SCAN_ID_NAME found in the REQUEST in this case, it means that
          we are creating an annex containing a generated document inclucing the barcode;
        - or annex is signed (it means that we are updating the annex thru the AMQP WS).'''
-    if getattr(annex, BARCODE_INSERTED_ATTR_ID, False) and \
+    if annex.scan_id and \
        not (annex.REQUEST.get(ITEM_SCAN_ID_NAME, False) or annex.signed):
-        setattr(annex, BARCODE_INSERTED_ATTR_ID, False)
+        annex.scan_id = None
 
 
 def onAnnexRemoved(annex, event):

--- a/src/Products/PloneMeeting/events.py
+++ b/src/Products/PloneMeeting/events.py
@@ -1034,9 +1034,16 @@ def onAnnexFileChanged(annex, event):
     '''Remove scan_id of annex if any, except:
        - if ITEM_SCAN_ID_NAME found in the REQUEST in this case, it means that
          we are creating an annex containing a generated document inclucing the barcode;
+       - currently duplicating an item, keeping/removing scan_id is managed by
+         ToolPloneMeeting.pasteItem;
+       - if ++add++annex in REQUEST, should not really happen, it means we are adding
+         a new annex and defining a scan_id for it (power user);
        - or annex is signed (it means that we are updating the annex thru the AMQP WS).'''
     if annex.scan_id and \
-       not (annex.REQUEST.get(ITEM_SCAN_ID_NAME, False) or annex.signed):
+       not (annex.REQUEST.get(ITEM_SCAN_ID_NAME, False) or
+            annex.REQUEST.get('currentlyPastingItems', False) or
+            '/++add++annex' in annex.REQUEST.getURL() or
+            annex.signed):
         annex.scan_id = None
 
 

--- a/src/Products/PloneMeeting/migrations/migrate_to_4210.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4210.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from imio.helpers.content import safe_delattr
+from Products.PloneMeeting.migrations import logger
+from Products.PloneMeeting.migrations import Migrator
+
+BARCODE_INSERTED_ATTR_ID = '_barcode_inserted'
+
+
+class Migrate_To_4210(Migrator):
+
+    def _removeBarcodeInsertedAttrOnAnnexes(self):
+        """ """
+        logger.info('Removing attribute "_barcode_inserted" on every annexes...')
+        brains = self.catalog(portal_type=['annex', 'annexDecision'])
+        for brain in brains:
+            if brain.scan_id:
+                safe_delattr(brain.getObject(), BARCODE_INSERTED_ATTR_ID)
+        logger.info('Done.')
+
+    def run(self, extra_omitted=[], from_migration_to_4200=False):
+
+        logger.info('Migrating to PloneMeeting 4210...')
+
+        self._removeBarcodeInsertedAttrOnAnnexes()
+
+        logger.info('Migrating to PloneMeeting 4210... Done.')
+
+
+def migrate(context):
+    '''This migration function will:
+
+       1) Remove attribute "_barcode_inserted" from annexes.
+    '''
+    migrator = Migrate_To_4210(context)
+    migrator.run()
+    migrator.finish()

--- a/src/Products/PloneMeeting/profiles.zcml
+++ b/src/Products/PloneMeeting/profiles.zcml
@@ -202,4 +202,12 @@
       handler="Products.PloneMeeting.migrations.migrate_to_4209.migrate"
       profile="Products.PloneMeeting:default" />
 
+  <genericsetup:upgradeStep
+      title="Go to PloneMeeting 4210"
+      description="Go to PloneMeeting 4210"
+      source="4209"
+      destination="4210"
+      handler="Products.PloneMeeting.migrations.migrate_to_4210.migrate"
+      profile="Products.PloneMeeting:default" />
+
 </configure>

--- a/src/Products/PloneMeeting/profiles/default/metadata.xml
+++ b/src/Products/PloneMeeting/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4209</version>
+  <version>4210</version>
   <dependencies>
     <dependency>profile-Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow</dependency>
     <dependency>profile-imio.dashboard:default</dependency>

--- a/src/Products/PloneMeeting/tests/PloneMeetingTestCase.py
+++ b/src/Products/PloneMeeting/tests/PloneMeetingTestCase.py
@@ -36,6 +36,7 @@ from Products.PloneMeeting.browser.meeting import _get_default_signatories
 from Products.PloneMeeting.browser.meeting import _get_default_voters
 from Products.PloneMeeting.config import DEFAULT_USER_PASSWORD
 from Products.PloneMeeting.config import ITEM_DEFAULT_TEMPLATE_ID
+from Products.PloneMeeting.config import ITEM_SCAN_ID_NAME
 from Products.PloneMeeting.config import TOOL_FOLDER_ANNEX_TYPES
 from Products.PloneMeeting.Meeting import Meeting_schema
 from Products.PloneMeeting.MeetingItem import MeetingItem_schema
@@ -462,6 +463,8 @@ class PloneMeetingTestCase(unittest.TestCase, PloneMeetingTestingHelpers):
         if relatedTo == 'item_decision':
             annexContentType = 'annexDecision'
 
+        # scan_id is removed by default
+        self.request.set(ITEM_SCAN_ID_NAME, scan_id)
         theAnnex = createContentInContainer(
             container=context,
             portal_type=annexContentType,
@@ -474,6 +477,7 @@ class PloneMeetingTestCase(unittest.TestCase, PloneMeetingTestingHelpers):
             signed=signed,
             publishable=publishable,
             scan_id=scan_id)
+        self.request.set(ITEM_SCAN_ID_NAME, None)
         # need to commit the transaction so the stored blob is correct
         # if not done, accessing the blob will raise 'BlobError: Uncommitted changes'
         transaction.commit()


### PR DESCRIPTION
See #MPMBRWP-32