### PR TITLE
Optimized `MeetingItem._updateAdvices` to avoid several computation of advisers when using inherited advices. This also fixes problem with optional key that was wrongly initialized for inherited advices.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 4.2.9rc3 (unreleased)
 ---------------------
 
-- Nothing changed yet.
-
+- Optimized `MeetingItem._updateAdvices` to avoid several computation of
+  advisers when using inherited advices. This also fixes problem with optional
+  key that was wrongly initialized for inherited advices.
+  [gbastien]
 
 4.2.9rc2 (2024-02-26)
 ---------------------

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -5339,9 +5339,8 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         res = []
         for adviserUid in adviserUids:
             # adviserId could not exist if we removed an inherited initiative advice for example
-            if not predecessor.adviceIndex.get(adviserUid, None):
-                continue
-            if (optional and not predecessor.adviceIndex[adviserUid]['optional']):
+            if not predecessor.adviceIndex.get(adviserUid, None) or \
+               not predecessor.adviceIndex[adviserUid]['optional'] == optional:
                 continue
             res.append(
                 {'org_uid': predecessor.adviceIndex[adviserUid]['id'],
@@ -6040,7 +6039,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
     def mandatoryAdvicesAreOk(self):
         '''Returns True if all mandatory advices for this item have been given and are all positive.'''
         if not hasattr(self, 'isRecurringItem'):
-            for advice in self.adviceIndex.itervalues():
+            for advice in self.adviceIndex.values():
                 if not advice['optional'] and \
                    not advice['type'].startswith('positive'):
                     return False
@@ -6317,6 +6316,8 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             org_uid for org_uid in self.adviceIndex
             if self.adviceIndex[org_uid].get('inherited', False) and
             org_uid not in handledAdviserUids]
+        # remove duplicates
+        unhandledAdviserUids = list(set(unhandledAdviserUids))
         if unhandledAdviserUids:
             optionalAdvisers += self.getUnhandledInheritedAdvisersData(
                 unhandledAdviserUids, optional=True)

--- a/src/Products/PloneMeeting/tests/testAdvices.py
+++ b/src/Products/PloneMeeting/tests/testAdvices.py
@@ -4261,6 +4261,20 @@ class testAdvices(PloneMeetingTestCase):
         # as we only know who created the advice
         self.assertIsNone(view.get_advice_given_by())
 
+    def test_pm_AdviceMandatoriness(self):
+        """When using MeetingConfig.enforceAdviceMandatoriness, an item
+           may only be presented if auto or delay-aware advices are positive."""
+        cfg = self.meetingConfig
+        cfg.setEnforceAdviceMandatoriness(True)
+        item1, item2, vendors_advice, developers_advice = \
+            self._setupInheritedAdvice()
+        self.changeUser('pmManager')
+        self.create('Meeting')
+        self.presentItem(item1)
+        self.assertEqual(item1.query_state(), 'presented')
+        self.presentItem(item2)
+        self.assertEqual(item2.query_state(), 'presented')
+
 
 def test_suite():
     from unittest import makeSuite


### PR DESCRIPTION
See #SUP-35490