### PR TITLE
Do not automatically reinitialize the delay of an advice during the `MeetingConfig.transitionsReinitializingDelays` if delay was timed out, this will have to be done manually.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ Changelog
   `description` instead `decision` as in some case (subplugin), `decision`
   field is not writable.
   [gbastien]
+- Do not automatically reinitialize the delay of an advice during the
+  `MeetingConfig.transitionsReinitializingDelays` if delay was timed out,
+  this will have to be done manually.
+  [gbastien]
 
 4.2.9rc5 (2024-03-14)
 ---------------------

--- a/src/Products/PloneMeeting/interfaces.py
+++ b/src/Products/PloneMeeting/interfaces.py
@@ -309,8 +309,8 @@ class IMeetingItemDocumentation:
            an adviser org_uid, this method will return the advice portal_type used by given p_org_uid."""
     def _adviceDelayWillBeReinitialized(self, org_uid, adviceInfo, isTransitionReinitializingDelays):
         """Will advice delay be reinitialized for given p_ord_uid?
-           By default delay is reinitialized if p_isTransitionReinitializingDelays
-           and if _advice_is_given."""
+           By default delay is reinitialized if p_isTransitionReinitializingDelays,
+           but if advice was not given and/or advice delay was not timed out."""
     def extraItemEvents(self):
         """Method for defining extra item events, needs to return a list of
            ids that will be used for id and translated for title."""


### PR DESCRIPTION
See #MPMBRWP-41