### PR TITLE
Renamed `_get_default_attendees` to `get_default_attendees`, `_get_default_signatories` to `get_default_signatories` and `_get_default_voters` to `_get_default_voters` and added it to `safe_utils` so it may be used in restricted python code.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Changelog
   `WriteMarginalNotes` that we should change name to a more generic name like
   `WriteClosedMeetingMeetingManagersReservedFields`.
   [gbastien]
+- Renamed `_get_default_attendees` to `get_default_attendees`,
+  `_get_default_signatories` to `get_default_signatories` and
+  `_get_default_voters` to `_get_default_voters` and added it to `safe_utils`
+  so it may be used in restricted python code.
+  [gbastien]
 
 4.2.13 (2024-12-06)
 -------------------

--- a/src/Products/PloneMeeting/browser/meeting.py
+++ b/src/Products/PloneMeeting/browser/meeting.py
@@ -267,36 +267,32 @@ class MeetingDefaultView(DefaultView, BaseMeetingView):
         manage_committees(self)
 
 
-def _get_default_attendees(context):
+def get_default_attendees(cfg):
     '''The default attendees are the active held_positions
        with 'present' in defaults.'''
-    res = []
-    used_held_positions = get_all_usable_held_positions(context)
-    res = [held_pos.UID() for held_pos in used_held_positions
+    res = [held_pos.UID() for held_pos in get_all_usable_held_positions(cfg)
            if held_pos.defaults and 'present' in held_pos.defaults]
     return res
 
 
-def _get_default_signatories(context, cfg):
+def get_default_signatories(cfg):
     '''The default signatories are the active held_positions
        with a defined signature_number.'''
     res = {}
     if "signatories" in cfg.getUsedMeetingAttributes():
-        used_held_positions = get_all_usable_held_positions(context)
-        signers = [held_pos for held_pos in used_held_positions
+        signers = [held_pos for held_pos in get_all_usable_held_positions(cfg)
                    if held_pos.defaults and 'present' in
                    held_pos.defaults and held_pos.signature_number]
         res = {signer.UID(): signer.signature_number for signer in signers}
     return res
 
 
-def _get_default_voters(context, cfg):
+def get_default_voters(cfg):
     '''The default voters are the active held_positions
        with 'voter' in defaults.'''
     res = []
     if cfg.getUseVotes():
-        used_held_positions = get_all_usable_held_positions(context)
-        res = [held_pos.UID() for held_pos in used_held_positions
+        res = [held_pos.UID() for held_pos in get_all_usable_held_positions(cfg)
                if held_pos.defaults and 'voter' in held_pos.defaults]
     return res
 
@@ -328,7 +324,7 @@ class AttendeesEditProvider(ContentProviderBase, BaseMeetingView):
         if is_meeting:
             attendees = self.context.get_attendees()
         else:
-            attendees = _get_default_attendees(self.context)
+            attendees = get_default_attendees(self.cfg)
         return attendees
 
     def get_excused(self):
@@ -354,7 +350,7 @@ class AttendeesEditProvider(ContentProviderBase, BaseMeetingView):
         if is_meeting:
             signatories = self.context.get_signatories()
         else:
-            signatories = _get_default_signatories(self.context, self.cfg)
+            signatories = get_default_signatories(self.cfg)
         return signatories
 
     def get_user_replacements(self):
@@ -372,7 +368,7 @@ class AttendeesEditProvider(ContentProviderBase, BaseMeetingView):
         if is_meeting:
             voters = self.context.get_voters()
         else:
-            voters = _get_default_voters(self.context, self.cfg)
+            voters = get_default_voters(self.cfg)
         return voters
 
     def checked(self, cbid, muid, stored_value, req_key="meeting_attendees"):
@@ -554,7 +550,7 @@ class MeetingFacetedView(BaseMeetingFacetedView):
                 if u'1' not in signature_numbers or u'2' not in signature_numbers:
                     # double check, maybe we are in a case
                     # where we only have one signatory
-                    default_signatories = _get_default_signatories(self.context, self.cfg)
+                    default_signatories = get_default_signatories(self.cfg)
                     if sorted(default_signatories.values()) != sorted(signature_numbers):
                         warn = True
             else:

--- a/src/Products/PloneMeeting/safe_utils.py
+++ b/src/Products/PloneMeeting/safe_utils.py
@@ -15,6 +15,9 @@ from imio.helpers.xhtml import unescape_html
 from imio.history.utils import getLastWFAction
 from Products.CPUtils.Extensions.utils import fileSize
 from Products.CPUtils.Extensions.utils import tobytes
+from Products.PloneMeeting.browser.meeting import get_default_attendees
+from Products.PloneMeeting.browser.meeting import get_default_signatories
+from Products.PloneMeeting.browser.meeting import get_default_voters
 from Products.PloneMeeting.browser.views import is_all_count
 from Products.PloneMeeting.browser.views import print_votes
 from Products.PloneMeeting.ftw_labels.utils import get_labels

--- a/src/Products/PloneMeeting/tests/PloneMeetingTestCase.py
+++ b/src/Products/PloneMeeting/tests/PloneMeetingTestCase.py
@@ -33,9 +33,9 @@ from plone.dexterity.utils import iterSchemata
 from Products.Archetypes.event import ObjectEditedEvent
 from Products.CMFPlone.utils import base_hasattr
 from Products.Five.browser import BrowserView
-from Products.PloneMeeting.browser.meeting import _get_default_attendees
-from Products.PloneMeeting.browser.meeting import _get_default_signatories
-from Products.PloneMeeting.browser.meeting import _get_default_voters
+from Products.PloneMeeting.browser.meeting import get_default_attendees
+from Products.PloneMeeting.browser.meeting import get_default_signatories
+from Products.PloneMeeting.browser.meeting import get_default_voters
 from Products.PloneMeeting.config import DEFAULT_USER_PASSWORD
 from Products.PloneMeeting.config import ITEM_DEFAULT_TEMPLATE_ID
 from Products.PloneMeeting.config import ITEM_SCAN_ID_NAME
@@ -382,15 +382,15 @@ class PloneMeetingTestCase(unittest.TestCase, PloneMeetingTestingHelpers):
             # manage attendees if using it
             usedMeetingAttrs = cfg.getUsedMeetingAttributes()
             if 'attendees' in usedMeetingAttrs:
-                default_attendees = _get_default_attendees(obj)
+                default_attendees = get_default_attendees(cfg)
                 default_attendees = OrderedDict((
                     (attendee, 'attendee') for attendee in default_attendees))
                 signatories = []
                 if 'signatories' in usedMeetingAttrs:
-                    signatories = _get_default_signatories(obj, cfg)
+                    signatories = get_default_signatories(cfg)
                 voters = []
                 if cfg.getUseVotes():
-                    voters = _get_default_voters(obj, cfg)
+                    voters = get_default_voters(cfg)
                 obj._do_update_contacts(attendees=default_attendees,
                                         signatories=signatories,
                                         voters=voters)

--- a/src/Products/PloneMeeting/tests/testMeeting.py
+++ b/src/Products/PloneMeeting/tests/testMeeting.py
@@ -28,7 +28,7 @@ from Products.CMFCore.permissions import ReviewPortalContent
 from Products.CMFCore.permissions import View
 from Products.Five import zcml
 from Products.PloneMeeting.adapters import CAN_NOT_DELETE_MEETING_ERROR
-from Products.PloneMeeting.browser.meeting import _get_default_attendees
+from Products.PloneMeeting.browser.meeting import get_default_attendees
 from Products.PloneMeeting.config import DEFAULT_LIST_TYPES
 from Products.PloneMeeting.config import ITEM_NO_PREFERRED_MEETING_VALUE
 from Products.PloneMeeting.config import MEETINGMANAGERS_GROUP_SUFFIX
@@ -3566,7 +3566,7 @@ class testMeetingType(PloneMeetingTestCase):
             u'can_not_define_several_same_signature_number',
             domain='PloneMeeting',
             context=self.request)
-        attendee_uids = _get_default_attendees(pm_folder)
+        attendee_uids = get_default_attendees(cfg)
         meeting_signatories = ['{0}__signaturenumber__1'.format(attendee_uids[0]),
                                '{0}__signaturenumber__1'.format(attendee_uids[1])]
         self.request.form['meeting_signatories'] = meeting_signatories


### PR DESCRIPTION
See #DLIBBDC-3097