### PR TITLE
Optimized `Meeting._update_using_groups_local_roles` that may be called on every existing meetings when saving several organizations in parameter `MeetingConfig.usingGroups`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,11 @@ Changelog
 4.2.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Optimized `Meeting._update_using_groups_local_roles` that may be called on
+  every existing meetings when saving several organizations in parameter
+  `MeetingConfig.usingGroups`.
+  This leaded to several minutes to save the `MeetingConfig`.
+  [gbastien]
 
 4.2.14 (2025-02-03)
 -------------------

--- a/src/Products/PloneMeeting/content/meeting.py
+++ b/src/Products/PloneMeeting/content/meeting.py
@@ -2276,7 +2276,8 @@ class Meeting(Container):
         tool = api.portal.get_tool('portal_plonemeeting')
         cfg = tool.getMeetingConfig(self)
         for org_uid in cfg.getUsingGroups():
-            for plone_group_id in get_plone_groups(org_uid, ids_only=True):
+            for plone_group_id in get_plone_groups(
+                    org_uid, ids_only=True, verify_group_exist=False):
                 self.manage_addLocalRoles(plone_group_id, ('Reader', ))
 
     security.declarePublic('wfConditions')

--- a/src/Products/PloneMeeting/tests/testPerformances.py
+++ b/src/Products/PloneMeeting/tests/testPerformances.py
@@ -998,6 +998,35 @@ class testPerformances(PloneMeetingTestCase):
                        'item with "{1}" vote(s)'.format(public, votes))
         item.restrictedTraverse('@@load_item_assembly_and_signatures')()
 
+    def test_pm_Speed_MeetingConfigEdit(self):
+        """Check editing a MeetingConfig, especially when using
+           MeetingConfig.usingGroups as this will update every existing
+           meetings and add local roles of selected usingGroups."""
+        self.changeUser("siteadmin")
+        cfg = self.meetingConfig
+        # create 100 groups
+        org_uids = []
+        pm_logger.info('Creating 100 organizations...')
+        for i in range(100):
+            org = self.create('organization', id=i, title='Org %d' % i)
+            org_uid = org.UID()
+            self._select_organization(org_uid)
+            org_uids.append(org_uid)
+        pm_logger.info('Done.')
+        cfg.setUsingGroups(org_uids)
+        # create 250 meetings
+        pm_logger.info('Creating 100 meetings...')
+        for i in range(100):
+            self.create('Meeting', date=datetime.now() + timedelta(i + 1))
+        pm_logger.info('Done.')
+        self._check_meeting_config_edit()
+
+    @timecall
+    def _check_meeting_config_edit(self):
+        ''' '''
+        pm_logger.info('Save MeetingConfig')
+        notify(ObjectEditedEvent(self.meetingConfig))
+
 
 def test_suite():
     from unittest import makeSuite


### PR DESCRIPTION
This leaded to several minutes to save the `MeetingConfig`.

See #PM-4287