### PR TITLE
When sending email notifications, prepend `MeetingConfig.configGroup` `full_label` when used and several `MeetingConfigs` have same title so we know from which `MeetingConfig` the notification is sent.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Changelog
 - Renamed `@@advice_delay_change_form` to `@@advice-delay-change-form`.
   Fixed `UnicodeDecodeError` when `delay_label` contains special characters.
   [gbastien]
+- When sending email notifications, prepend `MeetingConfig.configGroup`
+  `full_label` when used and several `MeetingConfigs` have same title
+  so we know from which `MeetingConfig` the notification is sent.
+  [gbastien]
 
 4.2.19 (2025-04-02)
 -------------------

--- a/src/Products/PloneMeeting/MeetingConfig.py
+++ b/src/Products/PloneMeeting/MeetingConfig.py
@@ -3550,12 +3550,21 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
     security.declarePublic('Title')
 
     def Title(self, include_config_group=False, **kwargs):
-        '''Returns the title and include config group value if p_include_config_group is True.'''
+        '''Returns the title and:
+           - include config group label if p_include_config_group is True;
+           - include config group full_label if p_include_config_group is "full_label".'''
         title = self.title
         if include_config_group and self.getConfigGroup():
-            # prepend configGroup
-            configGroupValue = self.Vocabulary('configGroup')[0].getValue(self.getConfigGroup())
-            title = u"{0} - {1}".format(configGroupValue, title)
+            if include_config_group is True:
+                # prepend configGroup label
+                title = u"{0} - {1}".format(
+                    safe_unicode(self.getConfigGroup(True)['label']), title)
+            elif include_config_group == "full_label":
+                full_label = self.getConfigGroup(True)['full_label']
+                if full_label:
+                    # prepend configGroup full_label
+                    title = u"{0} - {1}".format(
+                        safe_unicode(self.getConfigGroup(True)['full_label']), title)
         # Title returns utf-8
         return title.encode('utf-8')
 


### PR DESCRIPTION
See #DLIBBDC-3976