### PR TITLE
Display `MeetingConfig.configGroup` everywhere necessary to avoid mis interpretationwhen several `MeetingConfigs` have same title in different `configGroups`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ Changelog
   to update item WF to manage `WriteMarginalNotes` given to `MeetingManager`
   when item is `presented`.
   [gbastien]
+- Display `MeetingConfig.configGroup` everywhere necessary to avoid
+  misinterpretationwhen several `MeetingConfigs` have same title in different
+  `configGroups`.
+  [gbastien]
 
 4.2.22 (2025-05-14)
 -------------------

--- a/src/Products/PloneMeeting/content/content_category.py
+++ b/src/Products/PloneMeeting/content/content_category.py
@@ -3,6 +3,8 @@
 from collective.iconifiedcategory.content.category import CategorySchemaPolicy
 from collective.iconifiedcategory.content.subcategory import SubcategorySchemaPolicy
 from imio.helpers.content import uuidToObject
+from natsort import humansorted
+from operator import attrgetter
 from plone import api
 from plone.autoform import directives as form
 from Products.CMFPlone.utils import safe_unicode
@@ -100,7 +102,7 @@ class OtherMCCorrespondencesVocabulary(object):
                     ANNEX_NOT_KEPT.format(cfg_id),
                     ANNEX_NOT_KEPT.format(cfg_id),
                     u'%s ➔ %s ➔ %s' % (
-                        safe_unicode(cfg.Title()),
+                        safe_unicode(cfg.Title(include_config_group=True)),
                         translate('Item annexes',
                                   domain='PloneMeeting',
                                   context=context.REQUEST),
@@ -116,7 +118,7 @@ class OtherMCCorrespondencesVocabulary(object):
                             cat_uid,
                             cat_uid,
                             u'%s ➔ %s ➔ %s' % (
-                                safe_unicode(cfg.Title()),
+                                safe_unicode(cfg.Title(include_config_group=True)),
                                 safe_unicode(annexes_types_folder.Title()),
                                 safe_unicode(cat.Title()))))
                         for subcat in cat.objectValues():
@@ -125,11 +127,11 @@ class OtherMCCorrespondencesVocabulary(object):
                                 subcat_uid,
                                 subcat_uid,
                                 u'%s ➔ %s ➔ %s ➔ %s' % (
-                                    safe_unicode(cfg.Title()),
+                                    safe_unicode(cfg.Title(include_config_group=True)),
                                     safe_unicode(annexes_types_folder.Title()),
                                     safe_unicode(cat.Title()),
                                     safe_unicode(subcat.Title()))))
-        return SimpleVocabulary(res)
+        return SimpleVocabulary(humansorted(res, key=attrgetter('title')))
 
 
 OtherMCCorrespondencesVocabularyFactory = OtherMCCorrespondencesVocabulary()

--- a/src/Products/PloneMeeting/migrations/migrate_to_4215.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4215.py
@@ -34,9 +34,8 @@ class Migrate_To_4215(Migrator):
            Adapt WSC config so it is no more used in quickupload and clean broken annexes."""
         logger.info("Updating WSC config and removing broken annexes...")
         if self.portal.portal_quickinstaller.isProductInstalled('imio.webspellchecker'):
-            # disable WSC in input and textarea
-            if not get_disable_autosearch_in():
-                set_disable_autosearch_in(u'["#form-widgets-title", "#form-widgets-description"]')
+            # disable WSC in quickupload
+            set_disable_autosearch_in(u'["#form-widgets-title", "#form-widgets-description"]')
             # remove broken annexes
             self._removeBrokenAnnexes()
         logger.info('Done.')

--- a/src/Products/PloneMeeting/vocabularies.py
+++ b/src/Products/PloneMeeting/vocabularies.py
@@ -1318,26 +1318,29 @@ class SentToInfosVocabulary(object):
         tool = api.portal.get_tool('portal_plonemeeting')
         cfg = tool.getMeetingConfig(context)
         # the 'not to be cloned anywhere' term
-        res.append(SimpleTerm('not_to_be_cloned_to',
-                              'not_to_be_cloned_to',
-                              safe_unicode(translate('not_to_be_cloned_to_term',
-                                                     domain='PloneMeeting',
-                                                     context=context.REQUEST)))
-                   )
+        res.append(
+            SimpleTerm('not_to_be_cloned_to',
+                       'not_to_be_cloned_to',
+                       safe_unicode(translate('not_to_be_cloned_to_term',
+                                              domain='PloneMeeting',
+                                              context=context.REQUEST))))
         for cfgInfo in cfg.getMeetingConfigsToCloneTo():
             cfgId = cfgInfo['meeting_config']
-            cfgTitle = getattr(tool, cfgId).Title()
+            cfgTitle = getattr(tool, cfgId).Title(include_config_group=True)
             # add 'clonable to' and 'cloned to' options
             for suffix in ('__clonable_to', '__clonable_to_emergency',
                            '__cloned_to', '__cloned_to_emergency'):
                 termId = cfgId + suffix
-                res.append(SimpleTerm(termId,
-                                      termId,
-                                      translate('sent_to_other_mc_term' + suffix,
-                                                mapping={'meetingConfigTitle': safe_unicode(cfgTitle)},
-                                                domain='PloneMeeting',
-                                                context=context.REQUEST))
-                           )
+                res.append(
+                    SimpleTerm(
+                        termId,
+                        termId,
+                        translate(
+                            'sent_to_other_mc_term' + suffix,
+                            mapping={'meetingConfigTitle':
+                                safe_unicode(cfgTitle)},
+                            domain='PloneMeeting',
+                            context=context.REQUEST)))
         return SimpleVocabulary(res)
 
 
@@ -2925,9 +2928,12 @@ class OtherMCsClonableToVocabulary(object):
         cfg_ids = [mc['meeting_config'] for mc in cfg.getMeetingConfigsToCloneTo()]
         cfg_ids = list(set(cfg_ids).union(self._get_stored_values(context)))
         for cfg_id in cfg_ids:
-            terms.append(SimpleTerm(cfg_id,
-                                    cfg_id,
-                                    term_title or getattr(tool, cfg_id).Title()))
+            terms.append(
+                SimpleTerm(
+                    cfg_id,
+                    cfg_id,
+                    term_title or
+                    getattr(tool, cfg_id).Title(include_config_group=True)))
         return SimpleVocabulary(terms)
 
     # do ram.cache have a different key name


### PR DESCRIPTION
See #DLIBBDC-3997