### PR TITLE
Re-apply annexDecision to change permission for insert-barcode action from edit to view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Changelog
 - Added possibilty to display a `description` when using the `PMCheckBoxWidget`
   by defining a `description` on the `vocabulary term`.
   [gbastien]
+- Added new batch action `Insert barcode` on annexes and decision annexes.
+  [gbastien]
 
 4.2.28.10 (2026-03-13)
 ----------------------

--- a/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from imio.helpers.setup import load_type_from_package
 from Products.CMFPlone.utils import base_hasattr
 from Products.PloneMeeting.migrations import logger
 from Products.PloneMeeting.migrations import Migrator
@@ -36,13 +37,17 @@ class Migrate_To_4217_1(Migrator):
 
         logger.info('Migrating to PloneMeeting 4217.1...')
         self._configureCssTransforms()
+        # re-apply annexDecision as insert-barcode permission
+        # changed from ModifyPortalContent to View
+        load_type_from_package('annexDecision', 'Products.PloneMeeting:default')
         logger.info('Migrating to PloneMeeting 4217.1... Done.')
 
 
 def migrate(context):
     '''This migration function will:
 
-       1) Configure MeetingConfig.cssTransforms.
+       1) Configure MeetingConfig.cssTransforms;
+       2) Re-apply annexDecision portal_type to update "insert-barcode" permission.
     '''
     migrator = Migrate_To_4217_1(context)
     migrator.run()

--- a/src/Products/PloneMeeting/profiles/default/types/annexDecision.xml
+++ b/src/Products/PloneMeeting/profiles/default/types/annexDecision.xml
@@ -75,6 +75,6 @@
          link_target=""
          url_expr="string:${object/absolute_url}/@@insert-barcode"
          visible="True">
-  <permission value="Modify portal content"/>
+  <permission value="View"/>
  </action>
 </object>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Insert barcode" batch action for annexes and decision annexes.

* **Bug Fixes**
  * Adjusted barcode insertion permission on decision annexes to use View access instead of modify.

* **Documentation**
  * Recorded the new batch action in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->