### PR TITLE
Now that `IContentDeletable` adapter is used in `@@delete-batch-action` of `collective.eeafaceted.batchactions`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Changelog
   [gbastien]
 - Added new batch action `Insert barcode` on annexes and decision annexes.
   [gbastien]
+- Now that `IContentDeletable` adapter is used in `@@delete-batch-action` of
+  `collective.eeafaceted.batchactions`, this fixed the delete annexes batch
+  action that was failing when using WFA `only_creator_may_delete` and item was
+  no more in state `itemcreated`.
+  [gbastien]
 
 4.2.28.10 (2026-03-13)
 ----------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,5 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master
+collective.eeafaceted.batchactions = git ${remotes:imio}/collective.eeafaceted.batchactions.git pushurl=${remotes:imio_push}/collective.eeafaceted.batchactions.git branch=PM-4369_use_imio_actionspanel_deletable_functionnality_for_delete_batch_action
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4369_use_imio_actionspanel_deletable_functionnality_for_delete_batch_action

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,5 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-collective.eeafaceted.batchactions = git ${remotes:imio}/collective.eeafaceted.batchactions.git pushurl=${remotes:imio_push}/collective.eeafaceted.batchactions.git branch=PM-4369_use_imio_actionspanel_deletable_functionnality_for_delete_batch_action
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4369_use_imio_actionspanel_deletable_functionnality_for_delete_batch_action
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master

--- a/src/Products/PloneMeeting/browser/batchactions.py
+++ b/src/Products/PloneMeeting/browser/batchactions.py
@@ -353,11 +353,6 @@ class PMDeleteBatchActionForm(DeleteBatchActionForm):
         return "delete" in self.cfg.getEnabledAnnexesBatchActions() and \
             super(PMDeleteBatchActionForm, self).available()
 
-    def _get_deletable_elements(self):
-        """Get deletable elements using IContentDeletable."""
-        return [obj for obj in self.objs
-                if IContentDeletable(obj).mayDelete()]
-
 
 class PMConcatenateAnnexesBatchActionForm(ConcatenateAnnexesBatchActionForm):
     """ """

--- a/src/Products/PloneMeeting/tests/testWFAdaptations.py
+++ b/src/Products/PloneMeeting/tests/testWFAdaptations.py
@@ -5,6 +5,7 @@
 # GNU General Public License (GPL)
 #
 
+from AccessControl import Unauthorized
 from collective.behavior.internalnumber.browser.settings import get_settings
 from collective.behavior.internalnumber.browser.settings import set_settings
 from collective.contact.plonegroup.utils import get_all_suffixes
@@ -1550,6 +1551,7 @@ class testWFAdaptations(PloneMeetingTestCase):
     def _only_creator_may_delete_active(self):
         '''Tests while 'only_creator_may_delete' wfAdaptation is active.
            Only the 'MeetingMember' and the 'Manager' have the 'Delete objects' permission.'''
+        cfg = self.meetingConfig
         self.changeUser('pmCreator1')
         item = self.create('MeetingItem')
         self.assertEqual(item.query_state(), 'itemcreated')
@@ -1565,9 +1567,37 @@ class testWFAdaptations(PloneMeetingTestCase):
         self.changeUser('pmManager')
         # the MeetingManager can NOT delete
         self.failIf(self.hasPermission(DeleteObjects, item))
-        # God can delete too...
+        # Manager can delete
         self.changeUser('admin')
         self.failUnless(self.hasPermission(DeleteObjects, item))
+        # but annexes are still deletable by the users able to edit
+        # single delete
+        self.changeUser('pmManager')
+        annex = self.addAnnex(item)
+        decision_annex = self.addAnnex(item, relatedTo='item_decision')
+        self.assertEqual(get_annexes(item), [annex, decision_annex])
+        # not deletable by creator
+        self.changeUser('pmCreator1')
+        self.assertRaises(Unauthorized, item.restrictedTraverse('@@delete_givenuid'), annex.UID())
+        self.assertRaises(Unauthorized, item.restrictedTraverse('@@delete_givenuid'), decision_annex.UID())
+        # deletable by MeetingManager as item is "validated"
+        self.changeUser('pmManager')
+        self.portal.restrictedTraverse('@@delete_givenuid')(annex.UID())
+        self.portal.restrictedTraverse('@@delete_givenuid')(decision_annex.UID())
+        self.assertEqual(get_annexes(item), [])
+        # deletable using the delete batch action
+        annex = self.addAnnex(item)
+        decision_annex = self.addAnnex(item, relatedTo='item_decision')
+        self.assertEqual(get_annexes(item), [annex, decision_annex])
+        cfg.setEnabledAnnexesBatchActions(['delete'])
+        self.request['form.widgets.uids'] = u','.join([annex.UID(), decision_annex.UID()])
+        self.request.form['form.widgets.uids'] = self.request['form.widgets.uids']
+        self.request.form['ajax_load'] = 'dummy'
+        self.changeUser('pmManager')
+        form = item.restrictedTraverse('@@delete-batch-action')
+        form.update()
+        form.handleApply(form, None)
+        self.assertEqual(get_annexes(item), [])
 
     def test_pm_WFA_return_to_proposing_group(self):
         '''Test the workflowAdaptation 'return_to_proposing_group'.'''


### PR DESCRIPTION
This fixed the delete annexes batch action that was failing when using WFA `only_creator_may_delete` and item was no more in state `itemcreated`.

See #PM-4369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where annexes could not be properly deleted when the `only_creator_may_delete` workflow adaptation was active and items had transitioned beyond their initial state. Deletion is now handled correctly for both single and batch operations.

* **Tests**
  * Expanded test coverage to validate annex deletion under various workflow scenarios, including permissions checks and batch deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->