### PR TITLE
Pm 4409 item groups in charge notes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ Changelog
   action that was failing when using WFA `only_creator_may_delete` and item was
   no more in state `itemcreated`.
   [gbastien]
+- Added new field `MeetingItem.groupsInChargeNotes` configurable in
+  `MeetingConfig.itemFieldsConfig`.
+  [gbastien]
+- Adapted `ToolPloneMeeting.user_is_in_org` to be able to pass a list of
+  `org_id` or `org_uid`.
+  [gbastien]
 
 4.2.28.10 (2026-03-13)
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Changelog
 - Adapted `ToolPloneMeeting.user_is_in_org` to be able to pass a list of
   `org_id` or `org_uid`.
   [gbastien]
+- Fixed JS code passing `external_user_id` to `@@load-external-infos`
+  to avoid JS injection.
+  [gbastien]
 
 4.2.28.10 (2026-03-13)
 ----------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4409_item_groups_in_charge_notes

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -1572,6 +1572,23 @@ schema = Schema((
         vocabulary='listItemInitiators',
     ),
     TextField(
+        name='groupsInChargeNotes',
+        allowable_content_types=('text/html',),
+        widget=RichWidget(
+            condition="python: here.adapted().show_field('groupsInChargeNotes')",
+            description="GroupsInChargeNotes",
+            description_msgid="groups_in_charge_notes_descr",
+            label_msgid="PloneMeeting_label_groupsInChargeNotes",
+            label='Groupsinchargenotes',
+            i18n_domain='PloneMeeting',
+        ),
+        default_content_type="text/html",
+        default_output_type="text/x-html-safe",
+        searchable=True,
+        optional=True,
+        write_permission=View,
+    ),
+    TextField(
         name='inAndOutMoves',
         allowable_content_types=('text/html',),
         widget=RichWidget(

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -75,6 +75,7 @@ from Products.PloneMeeting.browser.itemvotes import next_vote_is_linked
 from Products.PloneMeeting.config import AddAdvice
 from Products.PloneMeeting.config import AUTO_COPY_GROUP_PREFIX
 from Products.PloneMeeting.config import BUDGETIMPACTEDITORS_GROUP_SUFFIX
+from Products.PloneMeeting.config import CONFIGURABLE_FIELD_NAMES
 from Products.PloneMeeting.config import CONSIDERED_NOT_GIVEN_ADVICE_VALUE
 from Products.PloneMeeting.config import DEFAULT_COPIED_FIELDS
 from Products.PloneMeeting.config import DUPLICATE_AND_KEEP_LINK_EVENT_ACTION
@@ -2665,8 +2666,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
     def show_field(self, field_name):
         '''See doc in interfaces.py.'''
         item = self.getSelf()
-        if not item.isDefinedInTool() and \
-            item.attribute_is_used(field_name):
+        if item.attribute_is_used(field_name):
             # evaluate TAL expression
             tool = api.portal.get_tool('portal_plonemeeting')
             cfg = tool.getMeetingConfig(item)
@@ -5005,7 +5005,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
 
     def _bypass_write_perm_check_for(self, fieldName):
         """See docstring in interfaces.py"""
-        if fieldName in ['neededFollowUp', 'providedFollowUp']:
+        if fieldName in CONFIGURABLE_FIELD_NAMES:
             item = self.getSelf()
             tool = api.portal.get_tool('portal_plonemeeting')
             cfg = tool.getMeetingConfig(item)
@@ -5040,10 +5040,10 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             self.adapted()._bypass_write_perm_check_for(fieldName)
         # write_permission is "View" for custom management
         # if bypassWritePermissionCheck is False, make sure write_permission
-        # is no more "View", set it to "Modify portal content"
+        # is no more "View", set it to "Manage portal"
         write_perm = field.write_permission
         if not bypassWritePermissionCheck and write_perm == "View":
-            write_perm = ModifyPortalContent
+            write_perm = ManagePortal
         res = checkMayQuickEdit(
             self,
             bypassWritePermissionCheck=bypassWritePermissionCheck,

--- a/src/Products/PloneMeeting/ToolPloneMeeting.py
+++ b/src/Products/PloneMeeting/ToolPloneMeeting.py
@@ -791,17 +791,22 @@ class ToolPloneMeeting(UniqueObject, OrderedBaseFolder, BrowserDefaultMixin):
                        using_groups=[]):
         """Check if user is member of one of the Plone groups linked
            to given p_org_id or p_org_uid.  Parameters are exclusive.
+           p_org_id or p_org_uid can be a single value or a list of values.
            Other parameters from p_user_id=None to p_the_objects=True
            are default values passed to get_orgs_for_user."""
         if not org_uid:
-            org_uid = org_id_to_uid(org_id)
-        return bool(org_uid in self.get_orgs_for_user(
+            if not hasattr(org_id, '__iter__'):
+                org_id = [org_id]
+                org_uid = [org_id_to_uid(_org_id) for _org_id in org_id]
+        if not hasattr(org_uid, '__iter__'):
+            org_uid = [org_uid]
+        return bool(set(org_uid).intersection(self.get_orgs_for_user(
             user_id=user_id,
             only_selected=only_selected,
             suffixes=suffixes,
             omitted_suffixes=omitted_suffixes,
             using_groups=using_groups,
-            the_objects=False))
+            the_objects=False)))
 
     security.declarePublic('getPloneMeetingFolder')
 

--- a/src/Products/PloneMeeting/ToolPloneMeeting.py
+++ b/src/Products/PloneMeeting/ToolPloneMeeting.py
@@ -795,10 +795,11 @@ class ToolPloneMeeting(UniqueObject, OrderedBaseFolder, BrowserDefaultMixin):
            Other parameters from p_user_id=None to p_the_objects=True
            are default values passed to get_orgs_for_user."""
         if not org_uid:
-            if not hasattr(org_id, '__iter__'):
+            # then we have an "org_id"
+            if isinstance(org_id, str):
                 org_id = [org_id]
-                org_uid = [org_id_to_uid(_org_id) for _org_id in org_id]
-        if not hasattr(org_uid, '__iter__'):
+            org_uid = [org_id_to_uid(_org_id) for _org_id in org_id]
+        if isinstance(org_uid, str):
             org_uid = [org_uid]
         return bool(set(org_uid).intersection(self.get_orgs_for_user(
             user_id=user_id,

--- a/src/Products/PloneMeeting/config.py
+++ b/src/Products/PloneMeeting/config.py
@@ -415,6 +415,8 @@ MEETING_ATTENDEES_ATTRS = (
     # place to store item votes
     'item_votes')
 
+CONFIGURABLE_FIELD_NAMES = ['groupsInChargeNotes', 'neededFollowUp', 'providedFollowUp']
+
 
 def registerClasses():
     '''ArchGenXML generated code does not register Archetype classes at the

--- a/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
@@ -33,6 +33,15 @@ class Migrate_To_4217_1(Migrator):
             delattr(cfg, 'hideCssClassesTo')
         logger.info('Done.')
 
+    def _updateGroupsInChargeNotes(self):
+        """Update config and init new fields related to groupsInChargeNotes."""
+        logger.info('Updating "itemFieldsConfig" about groupsInChargeNotes for every MeetingConfigs...')
+        # update new fields groupsInChargeNotes on items
+        self.initNewHTMLFields(
+            query={'meta_type': ('MeetingItem')},
+            field_names=('groupsInChargeNotes', ))
+        logger.info('Done.')
+
     def run(self, extra_omitted=[], from_migration_to_4200=False):
 
         logger.info('Migrating to PloneMeeting 4217.1...')
@@ -40,6 +49,7 @@ class Migrate_To_4217_1(Migrator):
         # re-apply annexDecision as insert-barcode permission
         # changed from ModifyPortalContent to View
         load_type_from_package('annexDecision', 'Products.PloneMeeting:default')
+        self._updateGroupsInChargeNotes()
         logger.info('Migrating to PloneMeeting 4217.1... Done.')
 
 
@@ -47,7 +57,8 @@ def migrate(context):
     '''This migration function will:
 
        1) Configure MeetingConfig.cssTransforms;
-       2) Re-apply annexDecision portal_type to update "insert-barcode" permission.
+       2) Re-apply annexDecision portal_type to update "insert-barcode" permission;
+       3) Update config and items for new field MeetingItem.groupsInChargeNotes.
     '''
     migrator = Migrate_To_4217_1(context)
     migrator.run()

--- a/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
@@ -36,6 +36,15 @@ class Migrate_To_4217_1(Migrator):
     def _updateGroupsInChargeNotes(self):
         """Update config and init new fields related to groupsInChargeNotes."""
         logger.info('Updating "itemFieldsConfig" about groupsInChargeNotes for every MeetingConfigs...')
+        # update MeetingConfig.itemFieldsConfig default for "groupsInChargeNotes"
+        for cfg in self.tool.objectValues('MeetingConfig'):
+            item_fields_config = cfg.getItemFieldsConfig()
+            if not "groupsInChargeNotes" in [row['name'] for row in item_fields_config]:
+                # use default value
+                default_value = cfg.Schema()['itemFieldsConfig'].getDefault(cfg)
+                gic_notes_config = [row for row in default_value if row['name'] == "groupsInChargeNotes"][0]
+                item_fields_config += (gic_notes_config, )
+                cfg.setItemFieldsConfig(item_fields_config)
         # update new fields groupsInChargeNotes on items
         self.initNewHTMLFields(
             query={'meta_type': ('MeetingItem')},

--- a/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4217_1.py
@@ -39,12 +39,14 @@ class Migrate_To_4217_1(Migrator):
         # update MeetingConfig.itemFieldsConfig default for "groupsInChargeNotes"
         for cfg in self.tool.objectValues('MeetingConfig'):
             item_fields_config = cfg.getItemFieldsConfig()
-            if not "groupsInChargeNotes" in [row['name'] for row in item_fields_config]:
+            if "groupsInChargeNotes" not in [row['name'] for row in item_fields_config]:
                 # use default value
                 default_value = cfg.Schema()['itemFieldsConfig'].getDefault(cfg)
-                gic_notes_config = [row for row in default_value if row['name'] == "groupsInChargeNotes"][0]
-                item_fields_config += (gic_notes_config, )
-                cfg.setItemFieldsConfig(item_fields_config)
+                gic_notes_config = [row for row in default_value if row['name'] == "groupsInChargeNotes"]
+                if gic_notes_config:
+                    gic_notes_config = gic_notes_config[0]
+                    item_fields_config += (gic_notes_config, )
+                    cfg.setItemFieldsConfig(item_fields_config)
         # update new fields groupsInChargeNotes on items
         self.initNewHTMLFields(
             query={'meta_type': ('MeetingItem')},

--- a/src/Products/PloneMeeting/profiles/__init__.py
+++ b/src/Products/PloneMeeting/profiles/__init__.py
@@ -588,6 +588,9 @@ class MeetingConfigDescriptor(Descriptor):
             {'name': "providedFollowUp",
              'view': "python: item.may_view_follow_up()",
              'edit': "python: item.may_edit_follow_up('providedFollowUp')"},
+            {'name': "groupsInChargeNotes",
+             'view': "python: tool.user_is_in_org(org_uid=item.getProposingGroup())",
+             'edit': "python: tool.user_is_in_org(org_uid=item.getGroupsInCharge())"},
         )
         self.votesResultTALExpr = ''
 

--- a/src/Products/PloneMeeting/profiles/__init__.py
+++ b/src/Products/PloneMeeting/profiles/__init__.py
@@ -589,9 +589,9 @@ class MeetingConfigDescriptor(Descriptor):
              'view': "python: item.may_view_follow_up()",
              'edit': "python: item.may_edit_follow_up('providedFollowUp')"},
             {'name': "groupsInChargeNotes",
-             'view': "python: tool.user_is_in_org(org_uid=[item.getProposingGroup()] + "
+             'view': "python: tool.isManager(cfg) or tool.user_is_in_org(org_uid=[item.getProposingGroup()] + "
                 "item.getGroupsInCharge())",
-             'edit': "python: tool.user_is_in_org(org_uid=item.getGroupsInCharge())"},
+             'edit': "python: tool.isManager(cfg) or tool.user_is_in_org(org_uid=item.getGroupsInCharge())"},
         )
         self.votesResultTALExpr = ''
 

--- a/src/Products/PloneMeeting/profiles/__init__.py
+++ b/src/Products/PloneMeeting/profiles/__init__.py
@@ -589,7 +589,8 @@ class MeetingConfigDescriptor(Descriptor):
              'view': "python: item.may_view_follow_up()",
              'edit': "python: item.may_edit_follow_up('providedFollowUp')"},
             {'name': "groupsInChargeNotes",
-             'view': "python: tool.user_is_in_org(org_uid=item.getProposingGroup())",
+             'view': "python: tool.user_is_in_org(org_uid=[item.getProposingGroup()] + "
+                "item.getGroupsInCharge())",
              'edit': "python: tool.user_is_in_org(org_uid=item.getGroupsInCharge())"},
         )
         self.votesResultTALExpr = ''

--- a/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_edit.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_edit.pt
@@ -101,6 +101,11 @@
         <metal:f use-macro="context/@@pm-macros/otherMeetingConfigsClonable"/>
     </tal:clonableToOtherMCsWithExtraFields>
 
+    <!-- groupsInChargeNotes field is not integrated in the edit form and only editable thru view/quick edit
+    <tal:field define="fieldName python: 'groupsInChargeNotes'">
+      <metal:f use-macro="context/@@pm-macros/editContentField"/>
+    </tal:field-->
+
     <tal:field define="fieldName python: 'inAndOutMoves'">
       <metal:f use-macro="context/@@pm-macros/editContentField"/>
     </tal:field>

--- a/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_view.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_view.pt
@@ -636,6 +636,11 @@
       </div>
     </tal:textCheckList>
 
+    <tal:comment replace="nothing">Groups in charge notes</tal:comment>
+    <tal:field define="fieldName python: 'groupsInChargeNotes'; ajaxEdit python:True">
+       <metal:f use-macro="context/@@pm-macros/viewContentField"/>
+    </tal:field>
+
     <tal:comment replace="nothing">In and out moves</tal:comment>
     <tal:field define="fieldName python: 'inAndOutMoves'; ajaxEdit python:True">
        <metal:f use-macro="context/@@pm-macros/viewContentField"/>

--- a/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_view.pt
+++ b/src/Products/PloneMeeting/skins/plonemeeting_templates/meetingitem_view.pt
@@ -470,7 +470,8 @@
     <tal:external-infos condition="python: context.restrictedTraverse('@@load-external-infos').show_section()">
         <div id="external-infos"
              class="collapsible discreet not-auto-collapsible-activable"
-             tal:attributes="onclick python: 'toggleDetails(\'collapsible-external-infos\', toggle_parent_active=true, parent_tag=null, load_view=\'@@load-external-infos?external_user_id=%s\');;' % request.get('external_user_id', '');">
+             tal:attributes="data-external-user-id python: request.get('external_user_id', '');
+                             onclick string:toggleDetails('collapsible-external-infos', toggle_parent_active=true, parent_tag=null, load_view='@@load-external-infos?external_user_id=' + encodeURIComponent(this.getAttribute('data-external-user-id')));;">
           <span class="item_attribute_label" i18n:translate="external_linked_elements">
               External linked elements
           </span>

--- a/src/Products/PloneMeeting/tests/helpers.py
+++ b/src/Products/PloneMeeting/tests/helpers.py
@@ -645,12 +645,13 @@ class PloneMeetingTestingHelpers(object):
         config.append(new_config)
         cfg.setLabelsConfig(config)
 
-    def _setupItemFieldsConfig(self, cfg, field_name, view=None, edit=None):
+    def _setupItemFieldsConfig(self, field_name, cfg=None, view=None, edit=None):
         """Configure MeetingConfig.itemFieldsConfig."""
+        cfg = cfg or self.meetingConfig
         config = cfg.getItemFieldsConfig()
-        field_config = [row for row in config if row['name'] == field_name]
+        field_config = [row for row in config if row['name'] == field_name][0]
         if view is not None:
             field_config['view'] = view
         if edit is not None:
             field_config['edit'] = edit
-        cfg.setItemFields(config)
+        cfg.setItemFieldsConfig(config)

--- a/src/Products/PloneMeeting/tests/helpers.py
+++ b/src/Products/PloneMeeting/tests/helpers.py
@@ -644,3 +644,13 @@ class PloneMeetingTestingHelpers(object):
         new_config['edit_access_on_cache'] = "0"
         config.append(new_config)
         cfg.setLabelsConfig(config)
+
+    def _setupItemFieldsConfig(self, cfg, field_name, view=None, edit=None):
+        """Configure MeetingConfig.itemFieldsConfig."""
+        config = cfg.getItemFieldsConfig()
+        field_config = [row for row in config if row['name'] == field_name]
+        if view is not None:
+            field_config['view'] = view
+        if edit is not None:
+            field_config['edit'] = edit
+        cfg.setItemFields(config)

--- a/src/Products/PloneMeeting/tests/helpers.py
+++ b/src/Products/PloneMeeting/tests/helpers.py
@@ -649,7 +649,10 @@ class PloneMeetingTestingHelpers(object):
         """Configure MeetingConfig.itemFieldsConfig."""
         cfg = cfg or self.meetingConfig
         config = cfg.getItemFieldsConfig()
-        field_config = [row for row in config if row['name'] == field_name][0]
+        field_config = [row for row in config if row['name'] == field_name]
+        if not field_config:
+            raise ValueError("field_name {0} config does not exist".format(field_name))
+        field_config = field_config[0]
         if view is not None:
             field_config['view'] = view
         if edit is not None:

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -9184,9 +9184,10 @@ class testMeetingItem(PloneMeetingTestCase):
         self.assertFalse(item.mayQuickEdit('neededFollowUp'))
         self.assertTrue(item.mayQuickEdit('providedFollowUp'))
 
-    def test_pm_groupsInChargeNotes(self):
-        """Test that it uses the MeetingConfig.itemFieldsConfig,
-           test that if edit is refused, it can not be edited."""
+    def test_pm_groups_in_charge_notes(self):
+        """Test that MeetingItem.groupsInChargeNotes uses
+           MeetingConfig.itemFieldsConfig.
+           Moreover, test that if edit condition is False, it can not be edited."""
         cfg = self.meetingConfig
         cfg.setOrderedGroupsInCharge((self.developers_uid, self.vendors_uid))
         cfg.setItemGroupsInChargeStates([self._stateMappingFor('itemcreated')])

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -5838,7 +5838,7 @@ class testMeetingItem(PloneMeetingTestCase):
             'takenOverBy', 'templateUsingGroups',
             'toDiscuss', 'committeeObservations', 'committeeTranscript',
             'votesObservations', 'votesResult',
-            'neededFollowUp', 'providedFollowUp',
+            'neededFollowUp', 'providedFollowUp', 'groupsInChargeNotes',
             'otherMeetingConfigsClonableToEmergency',
             'internalNotes', 'externalIdentifier']
         NEUTRAL_FIELDS += self._extraNeutralFields()
@@ -9183,6 +9183,32 @@ class testMeetingItem(PloneMeetingTestCase):
         self.changeUser('pmCreator1')
         self.assertFalse(item.mayQuickEdit('neededFollowUp'))
         self.assertTrue(item.mayQuickEdit('providedFollowUp'))
+
+    def test_pm_groupsInChargeNotes(self):
+        """Test that it uses the MeetingConfig.itemFieldsConfig,
+           test that if edit is refused, it can not be edited."""
+        cfg = self.meetingConfig
+        cfg.setOrderedGroupsInCharge((self.developers_uid, self.vendors_uid))
+        cfg.setItemGroupsInChargeStates([self._stateMappingFor('itemcreated')])
+        self._enableField(['groupsInCharge', 'groupsInChargeNotes'])
+        self.changeUser('pmCreator1')
+        item = self.create('MeetingItem', groupsInCharge=[self.vendors_uid])
+        # by default proposingGroup can view the field but not edit it
+        self.assertTrue(item.show_field('groupsInChargeNotes'))
+        # even if item editable, field can be not editable if condition if False
+        self.assertFalse(item.mayQuickEdit('groupsInChargeNotes'))
+        # group in charge can view and edit
+        self.changeUser('pmObserver2')
+        self.assertTrue(self.hasPermission(View, item))
+        self.assertTrue(item.show_field('groupsInChargeNotes'))
+        self.assertTrue(item.mayQuickEdit('groupsInChargeNotes'))
+        # make proposing group only able to edit
+        self._setupItemFieldsConfig(
+            'groupsInChargeNotes',
+            edit='python: tool.user_is_in_org(org_uid=item.getProposingGroup()')
+        self.assertFalse(item.mayQuickEdit('groupsInChargeNotes'))
+        self.changeUser('pmCreator1')
+        self.assertTrue(item.mayQuickEdit('groupsInChargeNotes'))
 
 
 def test_suite():

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -9146,7 +9146,7 @@ class testMeetingItem(PloneMeetingTestCase):
             '{"criterionId": "c1", "countByCollection": [{"count": 1, "uid": "%s"}]}' % neededfollowup_uid)
         self.assertEqual(len(neededfollowup.results()), 1)
         self.assertEqual(len(providedfollowup.results()), 0)
-        # provided-follow-up is available to MeetingManagerswhen field providedFollowUp is not empty
+        # provided-follow-up is available to MeetingManagers when field providedFollowUp is not empty
         self.assertFalse(
             'provided-follow-up' in
             [label['label_id'] for label in labelingview.available_labels()[1]])

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -9205,7 +9205,7 @@ class testMeetingItem(PloneMeetingTestCase):
         # make proposing group only able to edit
         self._setupItemFieldsConfig(
             'groupsInChargeNotes',
-            edit='python: tool.user_is_in_org(org_uid=item.getProposingGroup()')
+            edit='python: tool.user_is_in_org(org_uid=item.getProposingGroup())')
         self.assertFalse(item.mayQuickEdit('groupsInChargeNotes'))
         self.changeUser('pmCreator1')
         self.assertTrue(item.mayQuickEdit('groupsInChargeNotes'))

--- a/src/Products/PloneMeeting/tests/testUtils.py
+++ b/src/Products/PloneMeeting/tests/testUtils.py
@@ -19,6 +19,7 @@ from Products.PloneMeeting.ftw_labels.utils import get_labels
 from Products.PloneMeeting.tests.PloneMeetingTestCase import PloneMeetingTestCase
 from Products.PloneMeeting.utils import duplicate_portal_type
 from Products.PloneMeeting.utils import escape
+from Products.PloneMeeting.utils import is_proposing_group_editor
 from Products.PloneMeeting.utils import isPowerObserverForCfg
 from Products.PloneMeeting.utils import org_id_to_uid
 from Products.PloneMeeting.utils import sendMail
@@ -463,6 +464,27 @@ class testUtils(PloneMeetingTestCase):
             cfg, power_observer_types=['powerobservers', 'restrictedpowerobservers']))
         self.assertFalse(isPowerObserverForCfg(
             cfg, power_observer_types=['unknown']))
+
+    def test_pm_is_proposing_group_editor(self):
+        """Check if a user is an editor for a given org_uid."""
+        cfg = self.meetingConfig
+        self._setUpDefaultItemWFValidationLevels(cfg)
+        self.assertFalse(is_proposing_group_editor(self.developers_uid, cfg))
+        self.changeUser('pmCreator1')
+        self.assertTrue(is_proposing_group_editor(self.developers_uid, cfg))
+        self.assertFalse(is_proposing_group_editor(self.developers_uid, cfg, suffixes=['reviewers']))
+        self.assertFalse(is_proposing_group_editor(self.developers_uid, cfg, suffixes=['unknown']))
+        self.assertTrue(is_proposing_group_editor([self.developers_uid, self.vendors_uid], cfg))
+        self.assertFalse(is_proposing_group_editor([self.endUsers_uid, self.vendors_uid], cfg))
+        self.changeUser('pmCreator2')
+        self.assertFalse(is_proposing_group_editor(self.developers_uid, cfg))
+        self.assertTrue(is_proposing_group_editor(self.vendors_uid, cfg))
+        self.changeUser('pmObserver1')
+        self.assertFalse(is_proposing_group_editor(self.developers_uid, cfg))
+        self.assertFalse(is_proposing_group_editor(self.vendors_uid, cfg))
+        self.changeUser('pmReviewer1')
+        self.assertTrue(is_proposing_group_editor(self.developers_uid, cfg))
+        self.assertFalse(is_proposing_group_editor(self.vendors_uid, cfg))
 
 
 def test_suite():

--- a/src/Products/PloneMeeting/tests/testUtils.py
+++ b/src/Products/PloneMeeting/tests/testUtils.py
@@ -485,6 +485,9 @@ class testUtils(PloneMeetingTestCase):
         self.changeUser('pmReviewer1')
         self.assertTrue(is_proposing_group_editor(self.developers_uid, cfg))
         self.assertFalse(is_proposing_group_editor(self.vendors_uid, cfg))
+        # org_uid can be a list of org_uids
+        self.assertTrue(is_proposing_group_editor([self.developers_uid, self.vendors_uid], cfg))
+        self.assertFalse(is_proposing_group_editor([self.endUsers_uid, self.vendors_uid], cfg))
 
 
 def test_suite():

--- a/src/Products/PloneMeeting/utils.py
+++ b/src/Products/PloneMeeting/utils.py
@@ -2374,7 +2374,8 @@ def compute_item_roles_to_assign_to_suffixes(cfg, item, item_state, org_uid=None
 
 
 def is_proposing_group_editor(org_uid, cfg, suffixes=[]):
-    """ """
+    """Check if user is editor for given org_uid by getting editor suffixes from
+       MeetingConfig.itemWFValidationLevels."""
     suffixes = suffixes or cfg.getItemWFValidationLevels(data='suffix', only_enabled=True)
     return cfg.aq_parent.user_is_in_org(org_uid=org_uid, suffixes=suffixes)
 

--- a/src/Products/PloneMeeting/vocabularies.py
+++ b/src/Products/PloneMeeting/vocabularies.py
@@ -3417,7 +3417,7 @@ class ItemFieldsConfigVocabulary(object):
         terms = []
         item_attrs = context.listAttributes(MeetingItem.schema)
         # for now, only followUp related fields are configurable
-        configurable_field_names = ['neededFollowUp', 'providedFollowUp']
+        configurable_field_names = ['groupsInChargeNotes', 'neededFollowUp', 'providedFollowUp']
         for k, v in item_attrs.items():
             if k in configurable_field_names:
                 terms.append(SimpleTerm(k, k, v))

--- a/src/Products/PloneMeeting/vocabularies.py
+++ b/src/Products/PloneMeeting/vocabularies.py
@@ -55,6 +55,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.PloneMeeting.browser.itemvotes import next_vote_is_linked
 from Products.PloneMeeting.config import ADVICE_TYPES
 from Products.PloneMeeting.config import ALL_VOTE_VALUES
+from Products.PloneMeeting.config import CONFIGURABLE_FIELD_NAMES
 from Products.PloneMeeting.config import CONSIDERED_NOT_GIVEN_ADVICE_VALUE
 from Products.PloneMeeting.config import HIDDEN_DURING_REDACTION_ADVICE_VALUE
 from Products.PloneMeeting.config import ITEM_NO_PREFERRED_MEETING_VALUE
@@ -3416,10 +3417,8 @@ class ItemFieldsConfigVocabulary(object):
         """ """
         terms = []
         item_attrs = context.listAttributes(MeetingItem.schema)
-        # for now, only followUp related fields are configurable
-        configurable_field_names = ['groupsInChargeNotes', 'neededFollowUp', 'providedFollowUp']
         for k, v in item_attrs.items():
-            if k in configurable_field_names:
+            if k in CONFIGURABLE_FIELD_NAMES:
                 terms.append(SimpleTerm(k, k, v))
         return SimpleVocabulary(terms)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "Groups In Charge Notes" rich-text field on meeting items with ajax quick-edit for assigned groups; view/edit rules expose it to proposing and in‑charge groups as appropriate.
* **Migration**
  * Migration initializes the new field for existing configs and items.
* **Enhancements**
  * Membership checks accept multiple organization identifiers.
  * Centralized configuration drives which item fields are configurable.
* **Tests**
  * New/updated tests covering visibility, edit permissions and duplication.
* **Security**
  * Fixed JS input handling for external user IDs to prevent injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->