### PR TITLE
Refs/heads/pm 4400 follow up field access sync with follow up labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ Changelog
 - Make sure we store a boolean in `MeetingItem._labels_access_cache`
   `view_access` and `edit_access`.
   [gbastien]
+- Fixed `UnicodeDecodeError` in `MeetingItem.cloneToOtherMeetingConfig`,
+  when managing message `sendto_inexistent_destfolder_error` if destination
+  `MeetingConfig` title contains special characters.
+  [gbastien]
 
 4.2.28.15 (2026-04-24)
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Changelog
   [gbastien]
 - Added `obj` by default to `utils._base_extra_expr_ctx`.
   [gbastien]
+- Make sure we store a boolean in `MeetingItem._labels_access_cache`
+  `view_access` and `edit_access`.
+  [gbastien]
 
 4.2.28.15 (2026-04-24)
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,18 @@ Changelog
 - Use a real section to display `Back` link in `actions_panel`
   of config elements.
   [gbastien]
+- Changed default behavior of `MeetingItem.may_view_follow_up` used in
+  `MeetingConfig.itemFieldsconfig` to manage access to
+  `neededFollowUp/providedFollowUp` fields, now fields are viewable if labels
+  `needed-follow-up/provided-follow-up` are viewable.
+  Added parameters `only_viewable=False` and `only_editable=False` to
+  `ftw_labels.utils.get_labels`.
+  [gbastien]
+- Only compute `MeetingItem._bypass_write_perm_check_for` for
+  `CONFIGURABLE_FIELD_NAMES`.
+  [gbastien]
+- Added `obj` by default to `utils._base_extra_expr_ctx`.
+  [gbastien]
 
 4.2.28.15 (2026-04-24)
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changelog
   of config elements.
   [gbastien]
 - Changed default behavior of `MeetingItem.may_view_follow_up` used in
-  `MeetingConfig.itemFieldsconfig` to manage access to
+  `MeetingConfig.itemFieldsConfig` to manage access to
   `neededFollowUp/providedFollowUp` fields, now fields are viewable if labels
   `needed-follow-up/provided-follow-up` are viewable.
   Added parameters `only_viewable=False` and `only_editable=False` to

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4400_follow_up_field_access_sync_with_follow_up_labels
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4400_follow_up_field_access_sync_with_follow_up_labels

--- a/src/Products/PloneMeeting/MeetingConfig.py
+++ b/src/Products/PloneMeeting/MeetingConfig.py
@@ -2577,7 +2577,7 @@ schema = Schema((
                 'update_local_roles': SelectColumn(
                     "Labels config update local roles?",
                     col_description="labels_config_update_local_roles_col_description",
-                    vocabulary="listBooleanVocabulary",
+                    vocabulary_factory="ConfigLabelsConfigUpdateLocalRoles",
                     default='0'),
             },
             label='Labelsconfig',
@@ -6167,6 +6167,7 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
             ('1', translate('boolean_value_true', domain=d, context=self.REQUEST)),
         ))
         return res
+
 
     def listCommitteesEnabled(self):
         '''Vocabulary for committees.enabled datagrid column.'''

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -8459,14 +8459,15 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         cfg = tool.getMeetingConfig(self)
         if tool.isManager(realManagers=True):
             return True
-        is_manager = tool.isManager(cfg)
         # same condition for any field
         # must have relevant labels and MeetingManager
         # or when restricted=True, available to proposing group members
+        allowed = tool.isManager(cfg)
+        if restricted:
+            allowed = allowed or tool.user_is_in_org(
+                org_uid=self.getProposingGroup(), suffixes=suffixes)
         if (not fieldIsEmpty(field_name, self) or
-            get_labels(self, label_ids=label_ids, only_viewable=True)) and \
-           (not restricted or (is_manager or tool.user_is_in_org(
-                org_uid=self.getProposingGroup(), suffixes=suffixes))):
+                get_labels(self, label_ids=label_ids, only_viewable=True)) and allowed:
             return True
 
     def may_edit_follow_up(self,

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -7504,7 +7504,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             cache = getattr(self, ITEM_LABELS_ACCESS_CACHE_ATTR)
             cache.update(
                 compute_labels_access(
-                    adapter, cfg, item=self, item_state=self.query_state()))
+                    adapter, cfg, item=self, item_state=item_state))
 
     def _updateCommitteeEditorsLocalRoles(self, cfg, item_state):
         '''Add local roles depending on MeetingConfig.committees.'''
@@ -8460,8 +8460,9 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         if tool.isManager(realManagers=True):
             return True
         # same condition for any field
-        # must have relevant labels and MeetingManager
-        # or when restricted=True, available to proposing group members
+        # MeetingManager have always access
+        # when restricted=True, available to proposing group members
+        # or available if label viewable
         allowed = tool.isManager(cfg)
         if restricted:
             allowed = allowed or tool.user_is_in_org(

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -8461,15 +8461,14 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             return True
         # same condition for any field
         # MeetingManager have always access
-        # when restricted=True, available to proposing group members
-        # or available if label viewable
-        allowed = tool.isManager(cfg)
+        # when restricted=True, viewable to proposing group members
+        # when restricted=False, viewable if label viewable
+        is_manager = tool.isManager(cfg)
         if restricted:
-            allowed = allowed or tool.user_is_in_org(
+            return is_manager or tool.user_is_in_org(
                 org_uid=self.getProposingGroup(), suffixes=suffixes)
-        if (not fieldIsEmpty(field_name, self) or
-                get_labels(self, label_ids=label_ids, only_viewable=True)) and allowed:
-            return True
+        else:
+            return is_manager or get_labels(self, label_ids=label_ids, only_viewable=True)
 
     def may_edit_follow_up(self,
                            field_name='neededFollowUp',

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -7899,9 +7899,10 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             # While getting the destFolder, it could not exist, in this case
             # we return a clear message
             plone_utils.addPortalMessage(
-                translate('sendto_inexistent_destfolder_error',
-                          mapping={'meetingConfigTitle': destCfg.Title()},
-                          domain="PloneMeeting", context=self.REQUEST),
+                translate(
+                    'sendto_inexistent_destfolder_error',
+                    mapping={'meetingConfigTitle': safe_unicode(destCfg.Title())},
+                    domain="PloneMeeting", context=self.REQUEST),
                 type='error')
             return
         # The owner of the new item will be the same as the owner of the

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -75,6 +75,7 @@ from Products.PloneMeeting.browser.itemvotes import next_vote_is_linked
 from Products.PloneMeeting.config import AddAdvice
 from Products.PloneMeeting.config import AUTO_COPY_GROUP_PREFIX
 from Products.PloneMeeting.config import BUDGETIMPACTEDITORS_GROUP_SUFFIX
+from Products.PloneMeeting.config import CONFIGURABLE_FIELD_NAMES
 from Products.PloneMeeting.config import CONSIDERED_NOT_GIVEN_ADVICE_VALUE
 from Products.PloneMeeting.config import DEFAULT_COPIED_FIELDS
 from Products.PloneMeeting.config import DUPLICATE_AND_KEEP_LINK_EVENT_ACTION
@@ -5007,8 +5008,9 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
 
     def _bypass_write_perm_check_for(self, fieldName):
         """See docstring in interfaces.py"""
-        item = self.getSelf()
-        return item.adapted().show_field(fieldName, mode='edit')
+        if fieldName in CONFIGURABLE_FIELD_NAMES:
+            item = self.getSelf()
+            return item.adapted().show_field(fieldName, mode='edit')
 
     def _bypass_quick_edit_notify_modified_for(self, fieldName):
         """See docstring in interfaces.py"""
@@ -8449,6 +8451,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
     def may_view_follow_up(self,
                            field_name='neededFollowUp',
                            label_ids=('needed-follow-up', 'provided-follow-up'),
+                           restricted=False,
                            suffixes=[]):
         """Helper methods for default view access to followUp related fields."""
         tool = api.portal.get_tool('portal_plonemeeting')
@@ -8457,11 +8460,12 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             return True
         is_manager = tool.isManager(cfg)
         # same condition for any field
-        # must have relevant labels and MeetingManager or proposing group member
+        # must have relevant labels and MeetingManager
+        # or when restricted=True, available to proposing group members
         if (not fieldIsEmpty(field_name, self) or
-            get_labels(self, label_ids=label_ids)) and \
-           (is_manager or tool.user_is_in_org(
-                org_uid=self.getProposingGroup(), suffixes=suffixes)):
+            get_labels(self, label_ids=label_ids, only_viewable=True)) and \
+           (not restricted or (is_manager or tool.user_is_in_org(
+                org_uid=self.getProposingGroup(), suffixes=suffixes))):
             return True
 
     def may_edit_follow_up(self,

--- a/src/Products/PloneMeeting/browser/overrides.py
+++ b/src/Products/PloneMeeting/browser/overrides.py
@@ -1327,8 +1327,7 @@ class PMDocumentGenerationView(DashboardDocumentGenerationView):
         """Generates the stored annex title using the ConfigurablePODTemplate.store_as_annex_title_expr.
            If empty, we just return the ConfigurablePODTemplate title."""
         value = pod_template.store_as_annex_title_expr
-        extra_expr_ctx = _base_extra_expr_ctx(
-            self.context, {'obj': self.context, 'pod_template': pod_template})
+        extra_expr_ctx = _base_extra_expr_ctx(self.context, {'pod_template': pod_template})
         evaluatedExpr = _evaluateExpression(
             self.context,
             expression=value and value.strip() or '',

--- a/src/Products/PloneMeeting/ftw_labels/adapters.py
+++ b/src/Products/PloneMeeting/ftw_labels/adapters.py
@@ -248,12 +248,16 @@ class PMLabeling(Labeling):
         # first element of config is related to "*"
         config = self.cfg.getLabelsConfig(('*', ) + added_or_removed, data="update_local_roles")
         # we have:
-        # a config other than the default specifying to update local roles
+        # a config other than the default specifying to update local roles/update labels cache
         # or we do not have "0" for every selected elements and
-        # default config specify to update local roles
+        # default config specify to update local roles/update labels cache
+        # update local roles will update labels cache so we check it first
         if ("1" in config[1:]) or \
            (len(config) - 1 != len(added_or_removed) and config[0] == "1"):
             self.context.update_local_roles(avoid_reindex=True)
+        elif ("2" in config[1:]) or \
+           (len(config) - 1 != len(added_or_removed) and config[0] == "2"):
+            self.context._update_labels_access_cache(self.cfg, self.context.query_state())
         # invalidate collections counter cache and portlet_todo
         if set(active_label_ids).symmetric_difference(label_ids). \
                 intersection(self.get_searches_labels()):

--- a/src/Products/PloneMeeting/ftw_labels/utils.py
+++ b/src/Products/PloneMeeting/ftw_labels/utils.py
@@ -12,13 +12,13 @@ from Products.PloneMeeting.utils import _base_extra_expr_ctx
 from zope.component import getAdapter
 
 
-def get_labels(obj, include_personal_labels=True, label_ids=[], only_viewable=False, only_editable=False):
+def get_labels(obj, include_personal_labels=True, label_ids=None, only_viewable=False, only_editable=False):
     """Return active labels for p_obj.
        p_include_personal_labels may be:
        - True: returns every labels, personal or not;
        - False: personal labels not returned;
        - "only": only personal labels returned.
-       If p_label_ids, only consider these labels.
+       If p_label_ids, only consider these labels (a list of label ids).
        If p_only_viewable=True, we will check if label is viewable by current user.
        """
     res = {}

--- a/src/Products/PloneMeeting/ftw_labels/utils.py
+++ b/src/Products/PloneMeeting/ftw_labels/utils.py
@@ -76,12 +76,12 @@ def compute_labels_access(adapter,
                         extra_expr_ctx = _base_extra_expr_ctx(
                             item or cfg, {'item': item, })
                     data[config['label_id']]['view_access'] = \
-                        bool(
-                            _evaluateExpression(
-                                item or cfg,
-                                expression=config['view_access_on'],
-                                extra_expr_ctx=extra_expr_ctx,
-                                raise_on_error=True))
+                        _evaluateExpression(
+                            item or cfg,
+                            expression=config['view_access_on'],
+                            extra_expr_ctx=extra_expr_ctx,
+                            raise_on_error=True,
+                            return_bool=True)
         if "edit" in modes:
             # edit
             data[config['label_id']]['edit_groups'] = \
@@ -101,12 +101,12 @@ def compute_labels_access(adapter,
                         extra_expr_ctx = _base_extra_expr_ctx(
                             item or cfg, {'item': item, })
                     data[config['label_id']]['edit_access'] = \
-                        bool(
-                            _evaluateExpression(
-                                item or cfg,
-                                expression=config['edit_access_on'],
-                                extra_expr_ctx=extra_expr_ctx,
-                                raise_on_error=True))
+                        _evaluateExpression(
+                            item or cfg,
+                            expression=config['edit_access_on'],
+                            extra_expr_ctx=extra_expr_ctx,
+                            raise_on_error=True,
+                            return_bool=True)
     return data
 
 

--- a/src/Products/PloneMeeting/ftw_labels/utils.py
+++ b/src/Products/PloneMeeting/ftw_labels/utils.py
@@ -12,15 +12,31 @@ from Products.PloneMeeting.utils import _base_extra_expr_ctx
 from zope.component import getAdapter
 
 
-def get_labels(obj, include_personal_labels=True, label_ids=[]):
+def get_labels(obj, include_personal_labels=True, label_ids=[], only_viewable=False, only_editable=False):
     """Return active labels for p_obj.
        p_include_personal_labels may be:
        - True: returns every labels, personal or not;
        - False: personal labels not returned;
-       - "only": only personal labels returned."""
+       - "only": only personal labels returned.
+       If p_label_ids, only consider these labels.
+       If p_only_viewable=True, we will check if label is viewable by current user.
+       """
     res = {}
     labeling = ILabeling(obj)
     labels = labeling.active_labels()
+    modes = []
+    if only_viewable is True:
+        modes.append('view')
+    if only_editable is True:
+        modes.append('edit')
+    if modes:
+        # set active
+        for label in labels:
+            label['active'] = True
+        # need to pass personal labels to filter_manageable_labels, pass empty list
+        labels = labeling.filter_manageable_labels([[], labels], modes=modes)
+        # only keep global labels
+        labels = labels[1]
     for label in labels:
         if (include_personal_labels == "only" and not label['by_user']) or \
            (include_personal_labels is False and label['by_user']) or \

--- a/src/Products/PloneMeeting/ftw_labels/utils.py
+++ b/src/Products/PloneMeeting/ftw_labels/utils.py
@@ -76,11 +76,12 @@ def compute_labels_access(adapter,
                         extra_expr_ctx = _base_extra_expr_ctx(
                             item or cfg, {'item': item, })
                     data[config['label_id']]['view_access'] = \
-                        _evaluateExpression(
-                            item or cfg,
-                            expression=config['view_access_on'],
-                            extra_expr_ctx=extra_expr_ctx,
-                            raise_on_error=True)
+                        bool(
+                            _evaluateExpression(
+                                item or cfg,
+                                expression=config['view_access_on'],
+                                extra_expr_ctx=extra_expr_ctx,
+                                raise_on_error=True))
         if "edit" in modes:
             # edit
             data[config['label_id']]['edit_groups'] = \
@@ -100,11 +101,12 @@ def compute_labels_access(adapter,
                         extra_expr_ctx = _base_extra_expr_ctx(
                             item or cfg, {'item': item, })
                     data[config['label_id']]['edit_access'] = \
-                        _evaluateExpression(
-                            item or cfg,
-                            expression=config['edit_access_on'],
-                            extra_expr_ctx=extra_expr_ctx,
-                            raise_on_error=True)
+                        bool(
+                            _evaluateExpression(
+                                item or cfg,
+                                expression=config['edit_access_on'],
+                                extra_expr_ctx=extra_expr_ctx,
+                                raise_on_error=True))
     return data
 
 

--- a/src/Products/PloneMeeting/migrations/migrate_to_4216.py
+++ b/src/Products/PloneMeeting/migrations/migrate_to_4216.py
@@ -21,7 +21,7 @@ class Migrate_To_4216(Migrator):
             if not base_hasattr(cfg, 'enableLabels'):
                 continue
             if cfg.enableLabels:
-                logger.info("'labels' was enabled for MeetingConfig %s" % cfg.getId())
+                logger.info("'labels' was enabled for MeetingConfig '%s'" % cfg.getId())
                 used_item_attrs = list(cfg.getUsedItemAttributes())
                 used_item_attrs.append('labels')
                 cfg.setUsedItemAttributes(used_item_attrs)

--- a/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeetingpopups.js
+++ b/src/Products/PloneMeeting/skins/plonemeeting_styles/plonemeetingpopups.js
@@ -390,7 +390,6 @@ function addAdvicesBatchAction(){
                 return true;
             },
             onBeforeClose : function (e) {
-                return
                 // avoid closing overlay when click outside overlay
                 // or when it is closed by WSC
                 if (e.target.id == "exposeMask" ||
@@ -399,6 +398,7 @@ function addAdvicesBatchAction(){
                 // close every opened select2 widgets
                 $('.single-select2-widget').select2("close");
                 $('.multi-select2-widget').select2("close");
+                return true;
             },
         }
   });

--- a/src/Products/PloneMeeting/tests/helpers.py
+++ b/src/Products/PloneMeeting/tests/helpers.py
@@ -636,6 +636,10 @@ class PloneMeetingTestingHelpers(object):
         new_config = deepcopy(config[0])
         new_config['label_id'] = "needed-follow-up"
         new_config['edit_groups'] = ["configgroup_meetingmanagers"]
+        # everyone can see except powerobservers/restrictedpowerobservers
+        new_config['view_groups'] = [
+            "configgroup_powerobservers", "configgroup_restrictedpowerobservers"]
+        new_config['view_groups_excluding'] = '1'
         config.append(new_config)
         # provided-follow-up
         new_config = deepcopy(config[0])

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -9114,6 +9114,7 @@ class testMeetingItem(PloneMeetingTestCase):
         neededfollowup_uid = neededfollowup.UID()
         providedfollowup = cfg.searches.searches_items.searchitemswithprovidedfollowup
         self._setupFollowUp(cfg)
+        self._enableField('copyGroups')
 
         self.changeUser("pmCreator1")
         # check that counter is correct when using global labels
@@ -9121,7 +9122,7 @@ class testMeetingItem(PloneMeetingTestCase):
         self.assertEqual(
             view(),
             '{"criterionId": "c1", "countByCollection": [{"count": 0, "uid": "%s"}]}' % neededfollowup_uid)
-        item = self.create('MeetingItem', decision=self.decisionText)
+        item = self.create('MeetingItem', decision=self.decisionText, copyGroups=(self.vendors_reviewers, ))
         self.assertEqual(len(neededfollowup.results()), 0)
         self.assertEqual(len(providedfollowup.results()), 0)
         # providedFollowUp is not editable when label "needed-follow-up" is not set
@@ -9181,6 +9182,41 @@ class testMeetingItem(PloneMeetingTestCase):
         self.changeUser('pmCreator1')
         self.assertFalse(item.mayQuickEdit('neededFollowUp'))
         self.assertTrue(item.mayQuickEdit('providedFollowUp'))
+        # by default, users able to see the label can see the field
+        # copyGroup can see label and field
+        self.changeUser('pmReviewer2')
+        self.failUnless(self.hasPermission(View, item))
+        self.assertFalse(item.mayQuickEdit('neededFollowUp'))
+        self.assertFalse(item.mayQuickEdit('providedFollowUp'))
+        self.assertTrue('needed-follow-up' in get_labels(item, only_viewable=True))
+        self.assertTrue(item.show_field('neededFollowUp'))
+        self.assertTrue(item.show_field('providedFollowUp'))
+        # powerobserver can not see label so nor field
+        self.changeUser('powerobserver1')
+        self.failUnless(self.hasPermission(View, item))
+        self.assertFalse(item.mayQuickEdit('neededFollowUp'))
+        self.assertFalse(item.mayQuickEdit('providedFollowUp'))
+        self.assertFalse('needed-follow-up' in get_labels(item, only_viewable=True))
+        self.assertFalse(item.show_field('neededFollowUp'))
+        self.assertFalse(item.show_field('providedFollowUp'))
+        # can also be restricted to proposing group
+        self._setupItemFieldsConfig('neededFollowUp', view='python: item.may_view_follow_up(restricted=True)')
+        self.changeUser('pmReviewer2')
+        self.assertFalse(item.show_field('neededFollowUp'))
+        self.assertTrue(item.show_field('providedFollowUp'))
+        self.changeUser('pmCreator1')
+        self.assertTrue(item.show_field('neededFollowUp'))
+        self.assertTrue(item.show_field('providedFollowUp'))
+        self.changeUser('pmReviewer1')
+        self.assertTrue(item.show_field('neededFollowUp'))
+        self.assertTrue(item.show_field('providedFollowUp'))
+        self._setupItemFieldsConfig('neededFollowUp', view='python: item.may_view_follow_up(restricted=True, suffixes=["reviewers"])')
+        self.changeUser('pmCreator1')
+        self.assertFalse(item.show_field('neededFollowUp'))
+        self.assertTrue(item.show_field('providedFollowUp'))
+        self.changeUser('pmReviewer1')
+        self.assertTrue(item.show_field('neededFollowUp'))
+        self.assertTrue(item.show_field('providedFollowUp'))
 
     def test_pm_groups_in_charge_notes(self):
         """Test that MeetingItem.groupsInChargeNotes uses

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -9200,7 +9200,9 @@ class testMeetingItem(PloneMeetingTestCase):
         self.assertFalse(item.show_field('neededFollowUp'))
         self.assertFalse(item.show_field('providedFollowUp'))
         # can also be restricted to proposing group
-        self._setupItemFieldsConfig('neededFollowUp', view='python: item.may_view_follow_up(restricted=True)')
+        self._setupItemFieldsConfig(
+            'neededFollowUp',
+            view='python: item.may_view_follow_up(restricted=True)')
         self.changeUser('pmReviewer2')
         self.assertFalse(item.show_field('neededFollowUp'))
         self.assertTrue(item.show_field('providedFollowUp'))
@@ -9210,7 +9212,9 @@ class testMeetingItem(PloneMeetingTestCase):
         self.changeUser('pmReviewer1')
         self.assertTrue(item.show_field('neededFollowUp'))
         self.assertTrue(item.show_field('providedFollowUp'))
-        self._setupItemFieldsConfig('neededFollowUp', view='python: item.may_view_follow_up(restricted=True, suffixes=["reviewers"])')
+        self._setupItemFieldsConfig(
+            'neededFollowUp',
+            view='python: item.may_view_follow_up(restricted=True, suffixes=["reviewers"])')
         self.changeUser('pmCreator1')
         self.assertFalse(item.show_field('neededFollowUp'))
         self.assertTrue(item.show_field('providedFollowUp'))
@@ -9234,8 +9238,8 @@ class testMeetingItem(PloneMeetingTestCase):
         self.assertFalse(item.mayQuickEdit('groupsInChargeNotes'))
         # bypass for Manager
         self.changeUser('siteadmin')
-        self.assertTrue(item.show_field('groupsInChargeNotes')
-                        and item.mayQuickEdit('groupsInChargeNotes'))
+        self.assertTrue(item.show_field('groupsInChargeNotes') and
+                        item.mayQuickEdit('groupsInChargeNotes'))
         # group in charge can view and edit
         self.changeUser('pmObserver2')
         self.assertTrue(self.hasPermission(View, item))

--- a/src/Products/PloneMeeting/tests/testUtils.py
+++ b/src/Products/PloneMeeting/tests/testUtils.py
@@ -7,6 +7,7 @@
 
 from AccessControl import Unauthorized
 from collective.contact.plonegroup.utils import get_plone_group
+from copy import deepcopy
 from ftw.labels.interfaces import ILabeling
 from imio.helpers.content import richtextval
 from os import path
@@ -420,6 +421,7 @@ class testUtils(PloneMeetingTestCase):
     def test_pm_get_labels(self):
         """Test the ToolPloneMeeting.get_labels method
            that will return ftw.labels active_labels."""
+        cfg = self.meetingConfig
         self._enableField('labels')
         self.changeUser("pmCreator1")
         item = self.create("MeetingItem")
@@ -430,6 +432,20 @@ class testUtils(PloneMeetingTestCase):
         self.assertEqual(get_labels(item), {'label': 'Label', 'suivi': 'Suivi'})
         self.assertEqual(get_labels(item, False), {'label': 'Label'})
         self.assertEqual(get_labels(item, "only"), {'suivi': 'Suivi'})
+        # for now also viewable by reviewers
+        self.proposeItem(item)
+        self.changeUser("pmReviewer1")
+        self.assertEqual(get_labels(item, False), {'label': 'Label'})
+        config = list(cfg.getLabelsConfig())
+        # make 'label' only viewable by creators
+        new_config = deepcopy(config[0])
+        new_config['label_id'] = "label"
+        new_config['view_groups'] = ["suffix_proposing_group_creators"]
+        config.append(new_config)
+        cfg.setLabelsConfig(config)
+        item._update_labels_access_cache(cfg, item.query_state())
+        self.assertEqual(get_labels(item, False), {'label': 'Label'})
+        self.assertEqual(get_labels(item, False, only_viewable=True), {})
 
     def test_pm_IsPowerObserverForCfg(self):
         """ """

--- a/src/Products/PloneMeeting/tests/testViews.py
+++ b/src/Products/PloneMeeting/tests/testViews.py
@@ -3817,7 +3817,7 @@ class testViews(PloneMeetingTestCase):
         item.setTitle('Label1 not editable')
         item._update_after_edit()
         # edit_access and view_access are always stored as boolean values
-        # check view_access for with TAL expr is "python: 0"
+        # check view_access for which TAL expr is "python: 0"
         self.assertTrue(isinstance(item._labels_access_cache['label2']['view_access'], bool))
         self.request.form['activate_labels'] = []
         labelingview.update()
@@ -3846,6 +3846,7 @@ class testViews(PloneMeetingTestCase):
         # use global MeetingConfig.update_labels_access_cache to reflect
         # configuration changes, make "label2" viewable
         # for now we have "label" and "label1"
+        self.cleanMemoize()
         self.assertEqual(len(labelingview.available_labels(modes=['edit'])[1]), 2)
         config = list(cfg.getLabelsConfig())
         config[2]["edit_access_on"] = ""
@@ -3854,6 +3855,7 @@ class testViews(PloneMeetingTestCase):
         self.changeUser('siteadmin')
         cfg.update_labels_access_cache()
         self.changeUser('pmCreator1')
+        self.cleanMemoize()
         self.assertEqual(len(labelingview.available_labels(modes=['edit'])[1]), 3)
 
     def test_pm_AddAdviceBatchActionForm(self):

--- a/src/Products/PloneMeeting/tests/testViews.py
+++ b/src/Products/PloneMeeting/tests/testViews.py
@@ -3723,7 +3723,7 @@ class testViews(PloneMeetingTestCase):
         new_config2 = deepcopy(config[0])
         new_config2['label_id'] = "label2"
         new_config2['edit_access_on'] = "python: item.Title() != 'Label2 not editable'"
-        new_config2['view_access_on'] = "python: False"
+        new_config2['view_access_on'] = "python: 0"
         new_config2['edit_groups'] = []
         config.append(new_config1)
         config.append(new_config2)
@@ -3747,7 +3747,9 @@ class testViews(PloneMeetingTestCase):
         # try to remove 'label1', warning and still there
         item.setTitle('Label1 not editable')
         item._update_after_edit()
-
+        # edit_access and view_access are always stored as boolean values
+        # check view_access for with TAL expr is "python: 0"
+        self.assertTrue(isinstance(item._labels_access_cache['label2']['view_access'], bool))
         self.request.form['activate_labels'] = []
         labelingview.update()
         # set response status to 200 so status message is removed

--- a/src/Products/PloneMeeting/tests/testViews.py
+++ b/src/Products/PloneMeeting/tests/testViews.py
@@ -3705,6 +3705,75 @@ class testViews(PloneMeetingTestCase):
         self.assertEqual(get_labels(item), {})
         self.assertEqual(item.getAllCopyGroups(True), ())
 
+    def test_pm_LabelsConfigUpdateLocalRolesUpdateLabelsAccess(self):
+        """Test labelsConfig when a configuration specify to update labels access.
+           Here label "label2" is available when "label1" is selected."""
+        cfg = self.meetingConfig
+        self._enable_ftw_labels(cfg)
+        # label2 is available when label1 is selected
+        # for now, do not update labels
+        config = list(cfg.getLabelsConfig())
+        new_config = deepcopy(config[0])
+        new_config['label_id'] = "label2"
+        new_config['edit_access_on'] = \
+            "python: utils.get_labels(item, include_personal_labels=False, label_ids=['label1'])"
+        new_config['edit_groups'] = []
+        config.append(new_config)
+        cfg.setLabelsConfig(config)
+        self.changeUser('pmCreator1')
+        item = self.create('MeetingItem')
+        # label2 is not available
+        labelingview = item.restrictedTraverse('@@labeling')
+        # available_labels is cached
+        self.cleanMemoize()
+        self.assertEqual(
+            [label['label_id'] for label in labelingview.available_labels(modes=['edit'])[1]],
+            ['label', 'label1'])
+        self.request.form['activate_labels'] = ['label1']
+        labelingview.update()
+        # as update_local_roles is "0", labels access was not updated so "label2" is not available
+        self.assertTrue('label1' in get_labels(item))
+        labelingview = item.restrictedTraverse('@@labeling')
+        self.cleanMemoize()
+        self.assertEqual(
+            [label['label_id'] for label in labelingview.available_labels(modes=['edit'])[1]],
+            ['label', 'label1'])
+        # update config so it update labels when label1 is added/removed
+        new_config = deepcopy(config[0])
+        new_config['label_id'] = "label1"
+        new_config['update_local_roles'] = "2"
+        cfg.setLabelsConfig(config)
+        config.append(new_config)
+        cfg.setLabelsConfig(config)
+        # was not updated because updated when changed
+        labelingview.update()
+        labelingview = item.restrictedTraverse('@@labeling')
+        self.cleanMemoize()
+        self.assertEqual(
+            [label['label_id'] for label in labelingview.available_labels(modes=['edit'])[1]],
+            ['label', 'label1'])
+        # remove and add it again, this time labels access is updated
+        labelingview = item.restrictedTraverse('@@labeling')
+        self.request.form['activate_labels'] = []
+        labelingview.update()
+        self.assertEqual(get_labels(item), {})
+        self.request.form['activate_labels'] = ['label1']
+        labelingview = item.restrictedTraverse('@@labeling')
+        labelingview.update()
+        self.cleanMemoize()
+        self.assertEqual(
+            [label['label_id'] for label in labelingview.available_labels(modes=['edit'])[1]],
+            ['label', 'label1', 'label2'])
+        # removing the label will also update labels
+        self.request.form['activate_labels'] = []
+        labelingview = item.restrictedTraverse('@@labeling')
+        labelingview.update()
+        self.assertEqual(get_labels(item), {})
+        self.cleanMemoize()
+        self.assertEqual(
+            [label['label_id'] for label in labelingview.available_labels(modes=['edit'])[1]],
+            ['label', 'label1'])
+
     def test_pm_LabelsConfigWithNotViewableNotEditableLabels(self):
         """Test labelsConfig when editing an item containing labels where
            some are not viewable and/or editable.
@@ -3774,7 +3843,6 @@ class testViews(PloneMeetingTestCase):
         self.assertEqual(IStatusMessage(self.request).show(), [])
         # but 'label2' was kept as it is not viewable
         self.assertEqual(sorted(get_labels(item)), ['label1', 'label2'])
-        self.cleanMemoize()
         # use global MeetingConfig.update_labels_access_cache to reflect
         # configuration changes, make "label2" viewable
         # for now we have "label" and "label1"

--- a/src/Products/PloneMeeting/utils.py
+++ b/src/Products/PloneMeeting/utils.py
@@ -2006,7 +2006,7 @@ def getAvailableMailingLists(obj, pod_template, include_recipients=False):
     if not mailing_lists:
         return res
     try:
-        extra_expr_ctx = _base_extra_expr_ctx(obj, {'obj': obj, })
+        extra_expr_ctx = _base_extra_expr_ctx(obj)
         for line in mailing_lists.split('\n'):
             name, expression, userIds = line.split(';')
             if not expression or _evaluateExpression(
@@ -2039,7 +2039,7 @@ def extract_recipients(obj, values):
     # compile userIds in case we have a TAL expression
     recipients = []
     userIdsOrEmailAddresses = []
-    extra_expr_ctx = _base_extra_expr_ctx(obj, {'obj': obj, })
+    extra_expr_ctx = _base_extra_expr_ctx(obj)
     for value in values.strip().split(','):
         # value may be a TAL expression returning a list of userIds or email addresses
         # or a group (of users)
@@ -2492,7 +2492,8 @@ def _base_extra_expr_ctx(obj, extra_ctx={}):
     cfg = tool.getMeetingConfig(obj)
     # member, context and portal are managed by
     # collective.behavior.talcondition or collective.documentgenerator
-    data = {'tool': tool,
+    data = {'obj': obj,
+            'tool': tool,
             'cfg': cfg,
             # backward compatibility
             'meetingConfig': cfg,

--- a/src/Products/PloneMeeting/utils.py
+++ b/src/Products/PloneMeeting/utils.py
@@ -338,14 +338,11 @@ def createOrUpdatePloneGroup(groupId, groupTitle, groupSuffix):
     return wasCreated
 
 
-def fieldIsEmpty(name, obj, useParamValue=False, value=None):
+def fieldIsEmpty(name, obj, value=None):
     '''If field named p_name on p_obj empty ? The method checks emptyness of
        given p_value if p_useParamValue is True instead.'''
     field = obj.getField(name)
-    if useParamValue:
-        value = value
-    else:
-        value = field.get(obj)
+    value = value or field.get(obj)
     widgetName = field.widget.getName()
     if widgetName == 'RichWidget':
         return xhtmlContentIsEmpty(value)

--- a/src/Products/PloneMeeting/vocabularies.py
+++ b/src/Products/PloneMeeting/vocabularies.py
@@ -3472,7 +3472,9 @@ class BooleanVocabulary(object):
                     context=context.REQUEST)))
         return SimpleVocabulary(terms)
 
+
 BooleanVocabularyFactory = BooleanVocabulary()
+
 
 class ConfigLabelsConfigUpdateLocalRolesVocabulary(BooleanVocabulary):
     """ """
@@ -3482,8 +3484,8 @@ class ConfigLabelsConfigUpdateLocalRolesVocabulary(BooleanVocabulary):
            - '0': no update (default);
            - '1': update local roles;
            - '2': update labels access cache."""
-        vocab = super(ConfigLabelsConfigUpdateLocalRolesVocabulary, self).__call__(context)
-        vocab._terms.append(
+        terms = super(ConfigLabelsConfigUpdateLocalRolesVocabulary, self).__call__(context)._terms
+        terms.append(
             SimpleTerm(
                 '2',
                 '2',
@@ -3491,7 +3493,7 @@ class ConfigLabelsConfigUpdateLocalRolesVocabulary(BooleanVocabulary):
                     'labels_config_update_labels_access_cache',
                     domain="PloneMeeting",
                     context=context.REQUEST)))
-        return vocab
+        return SimpleVocabulary(terms)
 
 
 ConfigLabelsConfigUpdateLocalRolesVocabularyFactory = ConfigLabelsConfigUpdateLocalRolesVocabulary()

--- a/src/Products/PloneMeeting/vocabularies.py
+++ b/src/Products/PloneMeeting/vocabularies.py
@@ -3445,6 +3445,58 @@ class ConfigCssTransformsActionsVocabulary(object):
 ConfigCssTransformsActionsVocabularyFactory = ConfigCssTransformsActionsVocabulary()
 
 
+class BooleanVocabulary(object):
+    """ """
+    implements(IVocabularyFactory)
+    def __call__(self, context):
+        '''Vocabulary generating a boolean behaviour : just 2 values,
+           one yes/True, and the other no/False.
+           This is used in DataGridFields to avoid use of CheckBoxColumn
+           that does not handle validation correctly.'''
+        terms = []
+        terms.append(
+            SimpleTerm(
+                '0',
+                '0',
+                translate(
+                    'boolean_value_false',
+                    domain="PloneMeeting",
+                    context=context.REQUEST)))
+        terms.append(
+            SimpleTerm(
+                '1',
+                '1',
+                translate(
+                    'boolean_value_true',
+                    domain="PloneMeeting",
+                    context=context.REQUEST)))
+        return SimpleVocabulary(terms)
+
+BooleanVocabularyFactory = BooleanVocabulary()
+
+class ConfigLabelsConfigUpdateLocalRolesVocabulary(BooleanVocabulary):
+    """ """
+
+    def __call__(self, context):
+        """Vocabulary for labelsConfig.update_local_roles column with 3 values:
+           - '0': no update (default);
+           - '1': update local roles;
+           - '2': update labels access cache."""
+        vocab = super(ConfigLabelsConfigUpdateLocalRolesVocabulary, self).__call__(context)
+        vocab._terms.append(
+            SimpleTerm(
+                '2',
+                '2',
+                translate(
+                    'labels_config_update_labels_access_cache',
+                    domain="PloneMeeting",
+                    context=context.REQUEST)))
+        return vocab
+
+
+ConfigLabelsConfigUpdateLocalRolesVocabularyFactory = ConfigLabelsConfigUpdateLocalRolesVocabulary()
+
+
 class EveryConfigsVocabulary(object):
     """ """
 

--- a/src/Products/PloneMeeting/vocabularies.zcml
+++ b/src/Products/PloneMeeting/vocabularies.zcml
@@ -151,6 +151,10 @@
            name="PMEveryConfigs" />
   <utility component=".vocabularies.ConfigCssTransformsActionsVocabularyFactory"
            name="ConfigCssTransformsActions" />
+  <utility component=".vocabularies.BooleanVocabularyFactory"
+           name="BooleanVocabulary" />
+  <utility component=".vocabularies.ConfigLabelsConfigUpdateLocalRolesVocabularyFactory"
+           name="ConfigLabelsConfigUpdateLocalRoles" />
 
   <!-- PMHeldPosition vocabularies -->
   <utility component=".vocabularies.HeldPositionUsagesVocabularyFactory"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managers can view/edit configurable MeetingItem fields via settings.
  * New label-config mode to recalculate label availability without forcing local-role updates.

* **Bug Fixes**
  * Fixed encoding error when cloning items to configs with special-character titles.
  * Fixed overlay dialog closing behavior in batch actions.
  * Restricted POD template deletion to Zope administrators.

* **Improvements**
  * Finer access control and caching of label view/edit flags as booleans.
  * Clearer back-link display in action panels.

* **Tests / Docs**
  * Updated tests and unreleased changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->