### PR TITLE
Pm 4423 meeting item may ask advice again check back transition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,14 @@ Changelog
   when managing message `sendto_inexistent_destfolder_error` if destination
   `MeetingConfig` title contains special characters.
   [gbastien]
+- In `MeetingItem.mayAskAdviceAgain`, when using
+  `waiting_advices_proposing_group_send_back`, check that user can actually
+  send back by verifying that WF back transition can be triggered in case
+  it is overrided.
+  [gbastien]
+- In `MeetingItem.getCustomAdviceMessageFor`, display more complete default
+  messages when advice is `hidden during redaction` or `considered not given`.
+  [gbastien]
 
 4.2.28.15 (2026-04-24)
 ----------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4423_MeetingItem_mayAskAdviceAgain_check_back_transition

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4423_MeetingItem_mayAskAdviceAgain_check_back_transition
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -3116,10 +3116,13 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
                 if not found:
                     # make sure we have a list
                     states = [states]
-            suffixes = cfg.getItemWFValidationLevels(
-                states=states, data='suffix', only_enabled=True, return_state_singleton=False)
-            if tool.user_is_in_org(org_uid=org_uid, suffixes=suffixes):
-                return True
+            # make sure user actually able to back to states in case it was overrided
+            states = [state for state in states if item.wfConditions().mayCorrect(state)]
+            if states:
+                suffixes = cfg.getItemWFValidationLevels(
+                    states=states, data='suffix', only_enabled=True, return_state_singleton=False)
+                if tool.user_is_in_org(org_uid=org_uid, suffixes=suffixes):
+                    return True
         return False
 
     security.declarePublic('mayBackToPreviousAdvice')
@@ -5080,12 +5083,12 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             context = self.getSelf()
             if advice['advice_editable']:
                 customAdviceMessage = translate(
-                    'hidden_during_redaction',
+                    'advice_hidden_during_redaction_help',
                     domain='PloneMeeting',
                     context=context.REQUEST)
             else:
                 customAdviceMessage = translate(
-                    'considered_not_given_hidden_during_redaction',
+                    'advice_hidden_during_redaction_considered_not_given_help',
                     domain='PloneMeeting',
                     context=context.REQUEST)
         return {'displayDefaultComplementaryMessage': True,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of advice workflow transitions and correction requests, ensuring the system properly verifies if backward transitions to earlier workflow states can be triggered by users
  * Enhanced default help messaging displayed for advice items, providing more complete information when advice is hidden during redaction or marked as not given to requesters

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/Products.PloneMeeting/pull/322)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->