### PR TITLE
Fixed `MeetingItem.setManuallyLinkedItems` when current edit, a new selected value does not exist anymore (freshly removed for example).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Changelog
 - In `MeetingItem.getCustomAdviceMessageFor`, display more complete default
   messages when advice is `hidden during redaction` or `considered not given`.
   [gbastien]
+- Fixed `MeetingItem.setManuallyLinkedItems` when current edit, a new selected
+  value does not exist anymore (freshly removed for example).
+  [gbastien]
 
 4.2.28.15 (2026-04-24)
 ----------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4424_fix_set_manually_linked_items_unexisting_new_uid

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -3199,21 +3199,16 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         if '' in value:
             value.remove('')
 
-        # save value that will be actually stored on self as it will not be value
-        # if some extra uids are appended to it because linking to an item
-        # that is already linked to other items
-        valueToStore = list(value)
         # only compute if something changed
         if not set(stored) == set(value):
-
             # we will use unrestrictedSearchResults because in the case a user update manually linked items
             # and in already selected items, there is an item he can not view, it will be found in the catalog
             unrestrictedSearch = api.portal.get_tool('portal_catalog').unrestrictedSearchResults
-            item_infos = {}
+            cached_item_infos = {}
 
             def _get_item_infos(item_uid):
                 """Return meeting_date and item_created data for given p_item_uid."""
-                if not caching or item_uid not in item_infos:
+                if not caching or item_uid not in cached_item_infos:
                     item = self if item_uid == self.UID() else None
                     if item is None:
                         brains = unrestrictedSearch(UID=item_uid)
@@ -3223,23 +3218,30 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
                             item = brains[0]._unrestrictedGetObject()
                     if item:
                         meeting = item.getMeeting()
-                        item_infos[item_uid] = {
+                        cached_item_infos[item_uid] = {
                             'item': item,
                             'meeting_date': meeting and meeting.date or None,
                             'item_created': item.created()}
                     else:
-                        item_infos[item_uid] = None
-                return item_infos[item_uid]
+                        cached_item_infos[item_uid] = None
+                return cached_item_infos[item_uid]
+
+            # save value that will be actually stored on self as it will not be value
+            # if some extra uids are appended to it because linking to an item
+            # that is already linked to other items
+            # wipeout unexisting values to store in case some we removed
+            # between selection and save
+            value = [v for v in value if _get_item_infos(v)]
 
             # sorting method, items will be sorted by meeting date descending
             # then, for items that are not in a meeting date, by creation date
-            def _sortByMeetingDate(xUid, yUid):
+            def _sortByMeetingDate(x_uid, y_uid):
                 '''Sort method that will sort items by meetingDate.
                    x and y are uids of items to sort.'''
-                item1_infos = _get_item_infos(xUid)
+                item1_infos = _get_item_infos(x_uid)
                 item1_created = item1_infos['item_created']
                 item1_meeting_date = item1_infos['meeting_date']
-                item2_infos = _get_item_infos(yUid)
+                item2_infos = _get_item_infos(y_uid)
                 item2_created = item2_infos['item_created']
                 item2_meeting_date = item2_infos['meeting_date']
                 if item1_meeting_date and item2_meeting_date:
@@ -3271,8 +3273,8 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             # do not forget newUids
             newLinkedUids = newLinkedUids + newUids
             # we will also store this for self
-            valueToStore = list(set(valueToStore).union(newLinkedUids))
-            valueToStore.sort(_sortByMeetingDate)
+            value = list(set(value).union(newLinkedUids))
+            value.sort(_sortByMeetingDate)
             # for every linked items, also keep back link to self
             newLinkedUids.append(self.UID())
             # now update every item (newLinkedUids + value)
@@ -3309,7 +3311,7 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             self.REQUEST.set('manuallyLinkedItems_newLinkedUids', newLinkedUids)
             self.REQUEST.set('manuallyLinkedItems_removedUids', removedUids)
 
-            self.getField('manuallyLinkedItems').set(self, valueToStore, **kwargs)
+            self.getField('manuallyLinkedItems').set(self, value, **kwargs)
             # make change in linkedItem.at_ordered_refs until it is fixed in Products.Archetypes
             self._p_changed = True
 

--- a/src/Products/PloneMeeting/MeetingItem.py
+++ b/src/Products/PloneMeeting/MeetingItem.py
@@ -3203,19 +3203,12 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
         if not set(stored) == set(value):
             # we will use unrestrictedSearchResults because in the case a user update manually linked items
             # and in already selected items, there is an item he can not view, it will be found in the catalog
-            unrestrictedSearch = api.portal.get_tool('portal_catalog').unrestrictedSearchResults
             cached_item_infos = {}
 
             def _get_item_infos(item_uid):
                 """Return meeting_date and item_created data for given p_item_uid."""
                 if not caching or item_uid not in cached_item_infos:
-                    item = self if item_uid == self.UID() else None
-                    if item is None:
-                        brains = unrestrictedSearch(UID=item_uid)
-                        if brains:
-                            # there could be no brains when created from restapi call
-                            # as new item is still not indexed
-                            item = brains[0]._unrestrictedGetObject()
+                    item = self if item_uid == self.UID() else uuidToObject(item_uid, unrestricted=True)
                     if item:
                         meeting = item.getMeeting()
                         cached_item_infos[item_uid] = {
@@ -3297,10 +3290,9 @@ class MeetingItem(OrderedBaseFolder, BrowserDefaultMixin):
             # now if links were removed, remove linked items on every removed items...
             removedUids = set(stored).difference(set(value))
             for removedUid in removedUids:
-                removedItemBrains = unrestrictedSearch(UID=removedUid)
-                if not removedItemBrains:
+                removedItem = uuidToObject(removedUid, unrestricted=True)
+                if not removedItem:
                     continue
-                removedItem = removedItemBrains[0]._unrestrictedGetObject()
                 removedItem.getField('manuallyLinkedItems').set(removedItem, [], **kwargs)
                 # make change in linkedItem.at_ordered_refs until it is fixed in Products.Archetypes
                 removedItem._p_changed = True

--- a/src/Products/PloneMeeting/tests/testMeetingItem.py
+++ b/src/Products/PloneMeeting/tests/testMeetingItem.py
@@ -6296,6 +6296,9 @@ class testMeetingItem(PloneMeetingTestCase):
         item2.setManuallyLinkedItems([''])
         item3.setManuallyLinkedItems(['', item2UID, item4UID])
         item4.setManuallyLinkedItems(['', item1UID])
+        # if we edited an item, selected a linked item then delete the linked item before saving
+        item1.setManuallyLinkedItems(['no_more_existing_uid', item2UID, item3UID])
+        self.assertEqual(item1.getRawManuallyLinkedItems(), [item2UID, item3UID])
 
     def test_pm_ManuallyLinkedItemsCanUpdateEvenWithNotViewableItems(self):
         '''In case a user edit MeetingItem.manuallyLinkedItems field and does not have access


### PR DESCRIPTION
See #PM-4424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed manually linked items synchronization so removed or non-existent items are ignored and updates no longer fail.
* **Tests**
  * Extended tests to cover cases where a non-existent linked item is included during updates.
* **Documentation**
  * Changelog updated with the fix.
* **Chores**
  * Build configuration updated to track the intended source branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/Products.PloneMeeting/pull/323)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->