### PR TITLE
Rename every members meeting config folder title when `MeetingConfig.folderTitle` changed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Changelog
 4.2.28.17 (unreleased)
 ----------------------
 
-- Nothing changed yet.
-
+- Rename every members meeting config folder title when
+  `MeetingConfig.folderTitle` changed.
+  [gbastien]
 
 4.2.28.16 (2026-05-20)
 ----------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,5 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4017_update_meeting_folder_title_when_changed
-
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,5 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4017_update_meeting_folder_title_when_changed
+

--- a/src/Products/PloneMeeting/MeetingConfig.py
+++ b/src/Products/PloneMeeting/MeetingConfig.py
@@ -3811,7 +3811,7 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
     security.declareProtected(WriteRiskyConfig, 'setUsingGroups')
 
     def setUsingGroups(self, value, **kwargs):
-        '''Overrides the field 'setUsingGroups' mutator to enable or disable
+        '''Overrides the field 'usingGroups' mutator to enable or disable
            the MEETING_REMOVE_MOG_WFA WFA when relevant.
            Updating WF role mappings and every meetings local_roles is managed
            by the onConfigModified event.'''
@@ -3836,6 +3836,22 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
             # value changed, need to update local roles but WFA is already selected
             self.REQUEST.set('need_update_%s' % MEETING_REMOVE_MOG_WFA, True)
         self.getField('usingGroups').set(self, value, **kwargs)
+
+    security.declareProtected(WriteRiskyConfig, 'setFolderTitle')
+
+    def setFolderTitle(self, value, **kwargs):
+        '''Overrides the field 'folderTitle' mutator to rename every member folder
+           title when folderTitle changed.'''
+        stored = self.getField('folderTitle').get(self, **kwargs)
+        if stored != value:
+            folders = self._get_all_meeting_folders()
+            extras = 'number_of_elements={0} MeetingConfig={1} old_folder_title={2} new_folder_title={3}'.format(
+                len(folders), self.getId(), stored, value)
+            fplog('update_members_folder_title', extras=extras)
+            for folder in folders:
+                folder.setTitle(value)
+                folder.reindexObject(idxs=['Title'])
+        self.getField('folderTitle').set(self, value, **kwargs)
 
     security.declarePublic('getUsedVoteValues')
 
@@ -6529,6 +6545,8 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
                     portalType.icon_expr_object = Expression(portalType.icon_expr)
                     catalog = api.portal.get_tool('portal_catalog')
                     brains = catalog.unrestrictedSearchResults(portal_type=portal_type)
+                    extras = 'number_of_elements={0} portal_type={1}'.format(len(brains), portalType.id)
+                    fplog('update_item_icon_color', extras=extras)
                     pghandler = ZLogHandler(steps=1000)
                     pghandler.init(
                         'Updating items icon color ({0})...'.format(metaTypeName), len(brains))
@@ -8044,14 +8062,16 @@ class MeetingConfig(OrderedBaseFolder, BrowserDefaultMixin):
         """Return every meeting folders for this MeetingConfig."""
         folders = []
         portal = api.portal.get()
-        for userFolder in portal.Members.objectValues():
-            mymeetings = getattr(userFolder, 'mymeetings', None)
-            if not mymeetings:
-                continue
-            meetingFolder = getattr(mymeetings, self.getId(), None)
-            if not meetingFolder:
-                continue
-            folders.append(meetingFolder)
+        members = portal.get('Members')
+        if members:
+            for userFolder in members.objectValues():
+                mymeetings = getattr(userFolder, 'mymeetings', None)
+                if not mymeetings:
+                    continue
+                meetingFolder = getattr(mymeetings, self.getId(), None)
+                if not meetingFolder:
+                    continue
+                folders.append(meetingFolder)
         return folders
 
     def _synchSearches(self, folder=None):

--- a/src/Products/PloneMeeting/tests/testMeetingConfig.py
+++ b/src/Products/PloneMeeting/tests/testMeetingConfig.py
@@ -2814,6 +2814,23 @@ class testMeetingConfig(PloneMeetingTestCase):
         self._activate_wfas(['no_freeze', 'no_publication', 'no_decide'])
         self.assertEqual(cfg.get_transitions_to_close_a_meeting(), ['close'])
 
+    def test_pm_UpdateFolderTitle(self):
+        """When MeetingConfig.folderTitle changed, every members config folder
+           title is updated accordingly."""
+        cfg = self.meetingConfig
+        cfg_id = cfg.getId()
+        # create every member config folder
+        self.deleteAsManager(self.portal.Members.test_user_1_.UID())
+        for member_folder_id in self.portal.Members.objectIds():
+            self.changeUser(member_folder_id)
+            self.tool.getPloneMeetingFolder(cfg_id)
+        for member_folder in self.portal.Members.objectValues():
+            self.assertEqual(member_folder.mymeetings.get(cfg_id).Title(), cfg.getFolderTitle())
+        # change MeetingConfig.folderTitle, every members meeting config folders are updated accordingly
+        cfg.setFolderTitle('Another title héhé')
+        for member_folder in self.portal.Members.objectValues():
+            self.assertEqual(member_folder.mymeetings.get(cfg_id).Title(), cfg.getFolderTitle())
+
 
 def test_suite():
     from unittest import makeSuite


### PR DESCRIPTION
See #PM-4017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Meeting configuration folder names are now automatically renamed when the folder title setting is updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/Products.PloneMeeting/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->