### PR TITLE
Pm 4435 define different categorized childs infos for different types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,13 @@ Changelog
 4.2.28.17 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Registered a different `CategorizedChildInfosView._show_protected_download` for:
 
+  - `MeetingItem`: only shown to `MeetingManagers` and `proposingGroup` members;
+  - `Meeting`: only shown to `MeetingManagers`;
+  - `MeetingAdvice`: only shown to `MeetingManagers` and `advice_group advisers`.
+
+  [gbastien]
 
 4.2.28.16 (2026-05-20)
 ----------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,4 +2,4 @@
 extends = https://raw.githubusercontent.com/IMIO/buildout.pm/refs/heads/master/communes-dev.cfg
 
 [sources]
-Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=master
+Products.PloneMeeting = git ${remotes:imio}/Products.PloneMeeting.git pushurl=${remotes:imio_push}/Products.PloneMeeting.git branch=PM-4435_define_different_categorized-childs-infos_for_different_types

--- a/src/Products/PloneMeeting/browser/annexes.py
+++ b/src/Products/PloneMeeting/browser/annexes.py
@@ -265,9 +265,8 @@ class AdviceCategorizedChildInfosView(BaseCategorizedChildInfosView):
            Are allowed to download:
            - advice_group advisers members;
            - (Meeting)Managers."""
-        import ipdb; ipdb.set_trace()
         return super(AdviceCategorizedChildInfosView, self)._show_protected_download(element) or \
-            get_plone_group_id(self.context.advice_group, 'advisers') in self.tool.get_orgs_for_user()
+            get_plone_group_id(self.context.advice_group, 'advisers') in get_plone_groups_for_user()
 
 
 class PMBaseActionView(BaseActionView):

--- a/src/Products/PloneMeeting/browser/annexes.py
+++ b/src/Products/PloneMeeting/browser/annexes.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from collective.contact.plonegroup.utils import get_plone_group_id
 from collective.iconifiedcategory.browser.actionview import BaseView as BaseActionView
 from collective.iconifiedcategory.browser.actionview import ConfidentialChangeView
 from collective.iconifiedcategory.browser.actionview import PublishableChangeView
@@ -201,12 +202,12 @@ class PMCategorizedChildView(CategorizedChildView):
             portal_type, show_nothing, check_can_view)
 
 
-class PMCategorizedChildInfosView(CategorizedChildInfosView):
-    """ """
+class BaseCategorizedChildInfosView(CategorizedChildInfosView):
+    """@@categorized-childs-infos base class."""
 
     def __init__(self, context, request):
         """ """
-        super(PMCategorizedChildInfosView, self).__init__(context, request)
+        super(BaseCategorizedChildInfosView, self).__init__(context, request)
         self.tool = api.portal.get_tool('portal_plonemeeting')
         self.cfg = self.tool.getMeetingConfig(self.context)
 
@@ -217,16 +218,13 @@ class PMCategorizedChildInfosView(CategorizedChildInfosView):
 
     def show_preview(self, element):
         """Show preview if the auto_convert in collective.documentviewer is enabled."""
-        return super(PMCategorizedChildInfosView, self).show_preview(element) or \
+        return super(BaseCategorizedChildInfosView, self).show_preview(element) or \
             self.tool.auto_convert_annexes()
 
     def _show_protected_download(self, element):
         """When "show_preview" is "2", trigger advanced check.
-           Are allowed to download:
-           - proposingGroup members;
-           - (Meeting)Managers."""
-        return self.tool.isManager(self.cfg) or \
-            self.context.getProposingGroup() in self.tool.get_orgs_for_user()
+           By default shown to MeetingManagers."""
+        return self.tool.isManager(self.cfg)
 
     def show_nothing(self):
         """Do not display the 'Nothing' label."""
@@ -241,6 +239,35 @@ class PMCategorizedChildInfosView(CategorizedChildInfosView):
         annex_attr_config = '{0}_display'.format(detail_type)
         check = annex_attr_config in self.cfg.getAnnexRestrictShownAndEditableAttributes()
         return not check or self.tool.isManager(self.cfg)
+
+
+class MeetingCategorizedChildInfosView(BaseCategorizedChildInfosView):
+    """@@categorized-childs-infos for meetings."""
+
+
+class ItemCategorizedChildInfosView(BaseCategorizedChildInfosView):
+    """@@categorized-childs-infos for items."""
+
+    def _show_protected_download(self, element):
+        """When "show_preview" is "2", trigger advanced check.
+           Are allowed to download:
+           - proposingGroup members;
+           - (Meeting)Managers."""
+        return super(ItemCategorizedChildInfosView, self)._show_protected_download(element) or \
+            self.context.getProposingGroup() in self.tool.get_orgs_for_user()
+
+
+class AdviceCategorizedChildInfosView(BaseCategorizedChildInfosView):
+    """@@categorized-childs-infos for advices."""
+
+    def _show_protected_download(self, element):
+        """When "show_preview" is "2", trigger advanced check.
+           Are allowed to download:
+           - advice_group advisers members;
+           - (Meeting)Managers."""
+        import ipdb; ipdb.set_trace()
+        return super(AdviceCategorizedChildInfosView, self)._show_protected_download(element) or \
+            get_plone_group_id(self.context.advice_group, 'advisers') in self.tool.get_orgs_for_user()
 
 
 class PMBaseActionView(BaseActionView):

--- a/src/Products/PloneMeeting/browser/configure.zcml
+++ b/src/Products/PloneMeeting/browser/configure.zcml
@@ -1205,10 +1205,24 @@
             layer="collective.iconifiedcategory.interfaces.ICollectiveIconifiedCategoryLayer"
             template="browser/templates/categorized-childs.pt" />
         <browser:page
-            for="Products.PloneMeeting.interfaces.IMeetingContent"
+            for="Products.PloneMeeting.content.meeting.IMeeting"
             name="categorized-childs-infos"
             permission="zope2.Public"
-            class="Products.PloneMeeting.browser.annexes.PMCategorizedChildInfosView"
+            class="Products.PloneMeeting.browser.annexes.MeetingCategorizedChildInfosView"
+            layer="collective.iconifiedcategory.interfaces.ICollectiveIconifiedCategoryLayer"
+            template="browser/templates/categorized-childs-infos.pt" />
+        <browser:page
+            for="Products.PloneMeeting.interfaces.IMeetingItem"
+            name="categorized-childs-infos"
+            permission="zope2.Public"
+            class="Products.PloneMeeting.browser.annexes.ItemCategorizedChildInfosView"
+            layer="collective.iconifiedcategory.interfaces.ICollectiveIconifiedCategoryLayer"
+            template="browser/templates/categorized-childs-infos.pt" />
+        <browser:page
+            for="Products.PloneMeeting.content.advice.IMeetingAdvice"
+            name="categorized-childs-infos"
+            permission="zope2.Public"
+            class="Products.PloneMeeting.browser.annexes.AdviceCategorizedChildInfosView"
             layer="collective.iconifiedcategory.interfaces.ICollectiveIconifiedCategoryLayer"
             template="browser/templates/categorized-childs-infos.pt" />
         <browser:page

--- a/src/Products/PloneMeeting/profiles/testing/import_data.py
+++ b/src/Products/PloneMeeting/profiles/testing/import_data.py
@@ -112,9 +112,21 @@ adviceAnnex = AnnexTypeDescriptor(
     'advice-annex', 'Advice annex(es)', u'itemAnnex.png', relatedTo='advice')
 adviceLegalAnalysis = AnnexTypeDescriptor(
     'advice-legal-analysis', 'Advice legal analysis', u'legalAnalysis.png', relatedTo='advice')
+advicePreviewHideDownloadAnnex = AnnexTypeDescriptor(
+    'preview-hide-download-annex',
+    'Preview hide download annex',
+    u'itemAnnex.png',
+    relatedTo='advice',
+    show_preview=2)
 # Meeting annex types
 meetingAnnex = AnnexTypeDescriptor(
     'meeting-annex', 'Meeting annex(es)', u'itemAnnex.png', relatedTo='meeting')
+meetingPreviewHideDownloadAnnex = AnnexTypeDescriptor(
+    'preview-hide-download-annex',
+    'Preview hide download annex',
+    u'itemAnnex.png',
+    relatedTo='meeting',
+    show_preview=2)
 
 # Style Template ---------------------------------------------------------------
 stylesTemplate1 = StyleTemplateDescriptor('styles1', 'Default Styles')
@@ -295,7 +307,8 @@ meetingPma.meetingcategories = [mcategory1, mcategory2, mcategory3]
 meetingPma.annexTypes = [financialAnalysis, budgetAnalysisCfg1, overheadAnalysis,
                          itemAnnex, previewAnnex, previewHideDownloadAnnex,
                          decisionAnnex, marketingAnalysis,
-                         adviceAnnex, adviceLegalAnalysis, meetingAnnex]
+                         adviceAnnex, adviceLegalAnalysis, advicePreviewHideDownloadAnnex,
+                         meetingAnnex, meetingPreviewHideDownloadAnnex]
 meetingPma.usedItemAttributes = ('description', 'toDiscuss', 'itemTags', 'itemIsSigned',)
 meetingPma.usedMeetingAttributes = ('assembly', 'assembly_excused', 'assembly_absents',
                                     'assembly_guests', 'signatures', 'place',)
@@ -444,7 +457,8 @@ meetingPga.categories = [deployment, maintenance, development, events,
 meetingPga.classifiers = [classifier1, classifier2, classifier3]
 meetingPga.annexTypes = [financialAnalysis, legalAnalysis,
                          budgetAnalysisCfg2, itemAnnex, decisionAnnex,
-                         adviceAnnex, adviceLegalAnalysis, meetingAnnex]
+                         adviceAnnex, adviceLegalAnalysis, advicePreviewHideDownloadAnnex,
+                         meetingAnnex, meetingPreviewHideDownloadAnnex]
 meetingPga.usedItemAttributes = (
     'description', 'toDiscuss', 'associatedGroups', 'itemIsSigned', 'category', 'copyGroups')
 meetingPga.onMeetingTransitionItemActionToExecute = deepcopy(

--- a/src/Products/PloneMeeting/tests/testAnnexes.py
+++ b/src/Products/PloneMeeting/tests/testAnnexes.py
@@ -1311,7 +1311,8 @@ class testAnnexes(PloneMeetingTestCase):
         form_annex_widget_terms = [term.token for term in form_annex_widget.terms]
         self.assertEqual(
             form_annex_widget_terms,
-            ['{0}-annexes_types_-_meeting_annexes_-_meeting-annex'.format(cfgId)])
+            ['{0}-annexes_types_-_meeting_annexes_-_meeting-annex'.format(cfgId),
+             '{0}-annexes_types_-_meeting_annexes_-_preview-hide-download-annex'.format(cfgId)])
 
     def test_pm_AdviceAnnexFormVocabularies(self):
         """This is essentially done to make sure ++add++annex works
@@ -1329,7 +1330,8 @@ class testAnnexes(PloneMeetingTestCase):
         self.assertEqual(
             form_annex_widget_terms,
             ['{0}-annexes_types_-_advice_annexes_-_advice-annex'.format(cfgId),
-             '{0}-annexes_types_-_advice_annexes_-_advice-legal-analysis'.format(cfgId)])
+             '{0}-annexes_types_-_advice_annexes_-_advice-legal-analysis'.format(cfgId),
+             '{0}-annexes_types_-_advice_annexes_-_preview-hide-download-annex'.format(cfgId)])
 
     def test_pm_UpdateCategorizedElements(self):
         """The actions "update_categorized_elements" from collective.iconifiedcategory

--- a/src/Products/PloneMeeting/tests/testAnnexes.py
+++ b/src/Products/PloneMeeting/tests/testAnnexes.py
@@ -1813,13 +1813,21 @@ class testAnnexes(PloneMeetingTestCase):
     def test_pm_AnnexShowPreview(self):
         """Test when show_preview is defined on annex type."""
         cfg = self.meetingConfig
+        self._removeConfigObjectsFor(cfg)
         self._enableField('copyGroups')
         cfgItemWF = self.wfTool.getWorkflowsFor(cfg.getItemTypeName())[0]
         item_initial_state = self.wfTool[cfgItemWF.getId()].initial_state
         cfg.setItemCopyGroupsStates((item_initial_state, ))
         cfg.setSelectableCopyGroups((self.vendors_creators, ))
+        cfg.setItemAdviceStates((item_initial_state, ))
+        cfg.setItemAdviceEditStates((item_initial_state, ))
+
+        # item annex
         self.changeUser('pmCreator1')
-        item = self.create('MeetingItem', copyGroups=(self.vendors_creators, ))
+        item = self.create(
+            'MeetingItem',
+            copyGroups=(self.vendors_creators, ),
+            optionalAdvisers=(self.vendors_uid, ))
         annex0 = self.addAnnex(item)
         # must be PDF
         self.assertRaises(Invalid, self.addAnnex, item, annexType='preview-annex')
@@ -1877,6 +1885,24 @@ class testAnnexes(PloneMeetingTestCase):
         data = form.handleApply(form, None)
         m = magic.Magic()
         self.assertTrue(m.from_buffer(data).startswith('Zip archive data, at least v2.0 to extract'))
+
+        # meeting annex, only downloadable by MeetingManager
+        self.changeUser('pmManager')
+        meeting = self.create('Meeting')
+        meeting_annex = self.addAnnex(meeting, annexType='preview-hide-download-annex')
+        self.assertTrue(meeting_annex.show_download())
+        self.changeUser('pmCreator1')
+        self.assertFalse(meeting_annex.show_download())
+
+        # advice annex
+        self.changeUser('pmReviewer2')
+        advice = self.add_advice(item)
+        advice_annex = self.addAnnex(advice, annexType='preview-hide-download-annex')
+        self.assertTrue(advice_annex.show_download())
+        self.changeUser('pmCreator1')
+        self.assertFalse(advice_annex.show_download())
+        self.changeUser('pmManager')
+        self.assertTrue(advice_annex.show_download())
 
     def test_pm_AnonymousCanNotDownloadAnnex(self):
         """As we overrided can_view to let user download not viewable annexes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected protected annex (preview-hide-download) visibility based on content type in the categorized annexes view.
  - Meeting managers can access protected downloads for meetings.
  - Meeting items also allow access for proposing-group members.
  - Meeting advice allows access for meeting managers and designated advisers.
- **Tests**
  - Added coverage for protected-download visibility across meetings, meeting items, and advice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->